### PR TITLE
Add rain, rain delay and operation sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Last tested on OS API `2.1.8` and Home Assistant `0.88.1`
 ### Features
 
 - Binary sensors for each station to show on/off status
+- Binary sensors for OpenSprinkler operation, rain sensor and rain delay
 - Sensors for each station to show status
-- Sensors for water level and last run time
+- Sensors for water level, last run time and rain delay stop time
 - Programs as scenes which can be "activated"
 - Stations as switches with individual timers
 

--- a/hass_opensprinkler/binary_sensor.py
+++ b/hass_opensprinkler/binary_sensor.py
@@ -15,6 +15,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if len(stationIndexes) == 0 or (station.index in stationIndexes):
       sensors.append(StationBinarySensor(station))
 
+  sensors.append(OpenSprinklerBinarySensor('OpenSprinkler Operation', None, opensprinkler.enable_operation))
+  sensors.append(OpenSprinklerBinarySensor('Rain Sensor', 'moisture', opensprinkler.rain_sensor))
+  sensors.append(OpenSprinklerBinarySensor('Rain Delay', None, opensprinkler.rain_delay))
+
   add_devices(sensors, True)
 
 
@@ -38,3 +42,31 @@ class StationBinarySensor(BinarySensorDevice):
   def update(self):
     """Get the latest data """
     self._is_on = self._station.status()
+
+
+class OpenSprinklerBinarySensor(BinarySensorDevice):
+
+  def __init__(self, name, device_class, sensor):
+    self._name = name
+    self._sensor_type = device_class
+    self._sensor = sensor
+    self._is_on = False
+
+  @property
+  def device_class(self):
+    return self._sensor_type
+
+  @property
+  def name(self):
+    """Return the name of the binary sensor."""
+    return self._name
+
+  @property
+  def is_on(self):
+    """Return true if the binary sensor is on."""
+    return self._is_on
+
+  @Throttle(SCAN_INTERVAL)
+  def update(self):
+    """Get the latest data """
+    self._is_on = bool(self._sensor())

--- a/hass_opensprinkler/sensor.py
+++ b/hass_opensprinkler/sensor.py
@@ -20,6 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
   sensors.append(WaterLevelSensor(opensprinkler))
   sensors.append(LastRunSensor(opensprinkler))
+  sensors.append(RainDelayStopTimeSensor(opensprinkler))
 
   add_devices(sensors, True)
 
@@ -134,3 +135,41 @@ class LastRunSensor(Entity):
     self._last_run = self._opensprinkler.last_run()
     utcTime = datetime.fromtimestamp(self._last_run[3], utc_tz)
     self._state = utcTime.strftime("%d/%m %H:%M")
+
+
+class RainDelayStopTimeSensor(Entity):
+
+  def __init__(self, opensprinkler):
+    self._opensprinkler = opensprinkler
+    self._state = None
+    self._rain_delay_stop_time = None
+
+  @property
+  def name(self):
+    """Return the name of the binary sensor."""
+    return "Rain Delay Stop Time"
+
+  @property
+  def unit_of_measurement(self):
+    """Return the units of measurement."""
+    return None
+
+  @property
+  def icon(self):
+    """Return icon."""
+    return "mdi:weather-rainy"
+
+  @property
+  def state(self):
+    """Return the state of the sensor."""
+    return self._state
+
+  @Throttle(SCAN_INTERVAL)
+  def update(self):
+    """Fetch new state data for the sensor."""
+    self._rain_delay_stop_time = self._opensprinkler.rain_delay_stop_time()
+    if self._rain_delay_stop_time == 0:
+      self._state = 'Not in effect'
+    else:
+      utcTime = datetime.fromtimestamp(self._rain_delay_stop_time, utc_tz)
+      self._state = utcTime.strftime("%d/%m %H:%M")


### PR DESCRIPTION
This adds several additional binary sensors for the rain sesnor, rain
delay and whether operation is enabled in general, as well as a sensor
for the Rain Delay Stop Time.

Also features a minor bit of refactoring for querying controller
variables to reduce code duplication when hitting the `/jc` endpoint as
per the API (see
https://openthings.freshdesk.com/support/solutions/articles/5000716363-os-api-documents)