### PR TITLE
New: services to run programs and run/stop stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,60 @@
 ## hass-opensprinkler
 
-Opensprinkler custom component for Home Assistant
+OpenSprinkler custom component for Home Assistant
 
-Last tested on OS API `2.1.9` and Home Assistant `0.107.0`
+Last tested on OS API `2.1.9` and Home Assistant `0.110.0`
 
-![image](https://user-images.githubusercontent.com/819711/36068687-086820ce-0f2f-11e8-81de-de53c94124f0.png)
+## Features
 
-### Features
-
-- Binary sensors for each station to show on/off status
-- Binary sensors for each program to show enable/disable status
-- Binary sensors for OpenSprinkler operation, rain sensor and rain delay
+- Binary sensors for station and programs to show running state
 - Sensors for each station to show status
 - Sensors for water level, last run time and rain delay stop time
-- Programs as scenes which can be "activated"
-- Stations as switches with individual timers
-- Switches for each program to enable/disable program
-- Switch to enable/disable OpenSprinkler operation
+- Switches for each program and station to enable/disable program or station
+- Switch to enable/disable OpenSprinkler controller operation
+- Services to run and stop stations
+- Service to run programs
 
-### Installation
+## Installation
 
-1. Copy `custom_components/hass_opensprinkler` folder into `<config_dir>/custom_components`
-2. Add the following into your `configuration.yaml`
-    ```yaml
-    hass_opensprinkler:
-      host: <host>
-      password: <md5-password>
-    ```
-    - Replace `<host>` with the IP address or hostname of your Opensprinkler controller.  This should include the port number as well, such as `8080`, the default that OpenSprinkler uses, unless your install uses port `80`.  For example, `<hostname/ip address>:<port>`.
-    - Replace `<md5-password>` with the MD5 encrypted version of your password to your OpenSprinkler interface.  This is required, even if you have setup OpenSprinkler to not require a password.  It is considered to be a best-practice to store the password with [`secrets.yaml`](https://www.home-assistant.io/docs/configuration/secrets/).
-4. Check your config (either in the [UI](https://www.home-assistant.io/integrations/config#server-control) or [on the command line](https://www.home-assistant.io/docs/tools/check_config/)), and then restart Home Assistant
+1. Install using [HACS](https://github.com/custom-components/hacs). Or install manually by copying `custom_components/opensprinkler` folder into `<config_dir>/custom_components`
+2. Restart Home Assistant.
+3. In the Home Assistant UI, navigate to `Configuration` then `Integrations`. Click on the add integration button at the bottom right and select `OpenSprinkler`. Fill out the options and save.
 
-### Configuration
+### Upgrading from pre 1.0.0
 
-- `stations` - by default the component will retrieve all stations but you can limit which stations to show by providing a list of station indexes (starting from 0)
-    ```yaml
-    hass_opensprinkler:
-      ...
-      stations:
-        - 0
-        - 3
-        - 4
-    ```
+Note: *1.0.0 has major breaking changes, you will need to update any automations, scripts, etc*
 
-- `programs` - by default the component will retrieve all programs but you can limit which programs to show by providing a list of program indexes (starting from 0)
-    ```yaml
-    hass_opensprinkler:
-      ...
-      programs:
-        - 0
-        - 3
-    ```
+1. Remove yaml configuration.
+2. Uninstall using HACS or delete the `hass_opensprinkler` folder in `<config_dir>/custom_components`
+3. Restart Home Assistant
+4. Follow installation instructions above
 
-## Support for HACS
+#### Breaking Changes
 
-This custom component can be tracked with the help of [HACS](https://github.com/custom-components/hacs).
+- Program binary sensors now show running state instead of operation state. Please use the program switch states for program operation state.
+- Controller binary sensor is removed. Please use controller switch state for controller operation state.
+- Station switches now enable/disable instead of run/stop stations. Please use `opensprinkler.run_station` and `opensprinkler.stop_station` services to run and stop stations.
+- All scenes are removed. Please use the `opensprinkler.run_program` service to run programs.
 
-## Troubleshooting
+## Using Services
 
-#### My sprinkler switches are not working
-
-Some users have reported that thier switches do not work. This is due to some `input_number` entities not being created by the component. To get around this issue you can manually create these entities by adding the following for each of your stations.
+Available services are `opensprinkler.run_program`, `opensprinkler.run_station`, `opensprinkler.stop_station`.
 
 ```yaml
-input_number:
-  <station_name>_timer:
-    min: 1
-    max: 30
-    step: 1
-    mode: slider
+service: opensprinkler.run_program
+data:
+  entity_id: switch.program_name # Program switches
 ```
 
-Replace `<station_name` with your station name, it should match the names created for the `sensor`, `switch` and `binary_sensor`.
+```yaml
+service: opensprinkler.run_station
+data:
+  entity_id: switch.station_name # Station switches or sensors
+  run_seconds: 60 # Seconds to run for, optional
+```
+
+```yaml
+service: opensprinkler.stop_station
+data:
+  entity_id: switch.station_name # Station switches or sensors
+```

--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -135,7 +135,7 @@ class OpenSprinklerEntity(RestoreEntity):
 
     async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listeners and deregister API interest."""
-        super().async_will_remove_from_hass()
+        await super().async_will_remove_from_hass()
         self._coordinator.deregister_time_interval_listener()
 
     @Throttle(SCAN_INTERVAL)

--- a/custom_components/opensprinkler/const.py
+++ b/custom_components/opensprinkler/const.py
@@ -2,9 +2,15 @@
 
 from datetime import timedelta
 
+CONF_RUN_SECONDS = "run_seconds"
+
 DOMAIN = "opensprinkler"
 
 DEFAULT_NAME = "OpenSprinkler"
 DEFAULT_PORT = 8080
 
 SCAN_INTERVAL = timedelta(seconds=5)
+
+SERVICE_RUN_PROGRAM = "run_program"
+SERVICE_RUN_STATION = "run_station"
+SERVICE_STOP_STATION = "stop_station"

--- a/custom_components/opensprinkler/sensor.py
+++ b/custom_components/opensprinkler/sensor.py
@@ -2,13 +2,16 @@
 import logging
 from typing import Callable
 
+import voluptuous as vol
+
 from homeassistant.const import CONF_NAME, DEVICE_CLASS_TIMESTAMP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.dt import utc_from_timestamp
 
 from . import OpenSprinklerSensor
-from .const import DOMAIN
+from .const import CONF_RUN_SECONDS, DOMAIN, SERVICE_RUN_STATION, SERVICE_STOP_STATION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +22,14 @@ async def async_setup_entry(
     """Set up the OpenSprinkler sensors."""
     entities = _create_entities(hass, entry)
     async_add_entities(entities)
+
+    platform = entity_platform.current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_RUN_STATION, {vol.Required(CONF_RUN_SECONDS): cv.positive_int}, "run",
+    )
+    platform.async_register_entity_service(
+        SERVICE_STOP_STATION, {}, "stop",
+    )
 
 
 def _create_entities(hass: HomeAssistant, entry: dict):
@@ -173,3 +184,11 @@ class StationSensor(OpenSprinklerSensor, Entity):
     def _get_state(self) -> str:
         """Retrieve latest state."""
         return self._station.status
+
+    def run(self, run_seconds=60):
+        """Run station."""
+        return self._station.run(run_seconds)
+
+    def stop(self):
+        """Stop station."""
+        return self._station.stop()

--- a/custom_components/opensprinkler/services.yaml
+++ b/custom_components/opensprinkler/services.yaml
@@ -1,0 +1,21 @@
+run_program:
+  description: Runs a controller program
+  fields:
+    entity_id:
+      description: Program switch entity id
+      example: "switch.program_name"
+run_station:
+  description: Runs a controller station
+  fields:
+    entity_id:
+      description: Station sensor or switch entity id
+      example: "sensor.station_name"
+    run_seconds:
+      description: Number of seconds to run for (optional)
+      example: 60
+stop_station:
+  description: Stops a controller station
+  fields:
+    entity_id:
+      description: Station sensor or switch entity id
+      example: "sensor.station_name"


### PR DESCRIPTION
Closes #59 
Closes #60 

To test:

Developer Tools -> Services

Services available: `opensprinkler.run_program`, `opensprinkler.run_station`, `opensprinkler.stop_station`