### PR TITLE
async/coordinator support

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         async def async_update_data():
             """Fetch data from OpenSprinkler."""
-            print("refreshing OpenSprinkler data")
+            _LOGGER.debug("refreshing data")
             async with async_timeout.timeout(TIMEOUT):
                 await hass.async_add_executor_job(controller.refresh)
                 if not controller._state:
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
                 return controller._state
 
-        scan_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,

--- a/custom_components/opensprinkler/binary_sensor.py
+++ b/custom_components/opensprinkler/binary_sensor.py
@@ -17,7 +17,6 @@ from . import (
 from .const import (
     CONF_RUN_SECONDS,
     DOMAIN,
-    SCAN_INTERVAL,
     SCHEMA_SERVICE_RUN,
     SCHEMA_SERVICE_STOP,
     SERVICE_RUN,

--- a/custom_components/opensprinkler/const.py
+++ b/custom_components/opensprinkler/const.py
@@ -1,8 +1,6 @@
 """Define constants for the OpenSprinkler component."""
 import voluptuous as vol
 
-from datetime import timedelta
-
 from homeassistant.helpers import config_validation as cv
 
 CONF_INDEX = "index"
@@ -13,7 +11,7 @@ DOMAIN = "opensprinkler"
 DEFAULT_NAME = "OpenSprinkler"
 DEFAULT_PORT = 8080
 
-SCAN_INTERVAL = timedelta(seconds=5)
+DEFAULT_SCAN_INTERVAL = 5
 
 SCHEMA_SERVICE_RUN_SECONDS = {
     vol.Required(CONF_INDEX): cv.positive_int,

--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -2,7 +2,7 @@
   "domain": "opensprinkler",
   "name": "OpenSprinkler",
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
-  "requirements": ["pyopensprinkler==0.6.4"],
+  "requirements": ["pyopensprinkler==0.6.5"],
   "dependencies": [],
   "codeowners": ["@vinteo"],
   "config_flow": true

--- a/custom_components/opensprinkler/sensor.py
+++ b/custom_components/opensprinkler/sensor.py
@@ -17,7 +17,6 @@ from . import (
 from .const import (
     CONF_RUN_SECONDS,
     DOMAIN,
-    SCAN_INTERVAL,
     SCHEMA_SERVICE_RUN,
     SCHEMA_SERVICE_STOP,
     SERVICE_RUN,

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -15,7 +15,6 @@ from . import (
 from .const import (
     CONF_RUN_SECONDS,
     DOMAIN,
-    SCAN_INTERVAL,
     SCHEMA_SERVICE_RUN,
     SCHEMA_SERVICE_STOP,
     SERVICE_RUN,
@@ -90,15 +89,15 @@ class ControllerOperationSwitch(
         """Retrieve latest state."""
         return bool(self._controller.enabled)
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Enable the controller operation."""
-        self._controller.enable()
-        self._state = True
+        await self.hass.async_add_executor_job(self._controller.enable)
+        await self._coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Disable the device operation."""
-        self._controller.disable()
-        self._state = False
+        await self.hass.async_add_executor_job(self._controller.disable)
+        await self._coordinator.async_request_refresh()
 
 
 class ProgramEnabledSwitch(
@@ -134,15 +133,15 @@ class ProgramEnabledSwitch(
         """Retrieve latest state."""
         return bool(self._program.enabled)
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Enable the program."""
-        self._program.enable()
-        self._state = True
+        await self.hass.async_add_executor_job(self._program.enable)
+        await self._coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Disable the program."""
-        self._program.disable()
-        self._state = False
+        await self.hass.async_add_executor_job(self._program.disable)
+        await self._coordinator.async_request_refresh()
 
 
 class StationEnabledSwitch(
@@ -184,12 +183,12 @@ class StationEnabledSwitch(
         """Retrieve latest state."""
         return bool(self._station.enabled)
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Enable the station."""
-        self._station.enable()
-        self._state = True
+        await self.hass.async_add_executor_job(self._station.enable)
+        await self._coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Disable the station."""
-        self._station.disable()
-        self._state = False
+        await self.hass.async_add_executor_job(self._station.disable)
+        await self._coordinator.async_request_refresh()


### PR DESCRIPTION
Use the upstream `coordinator` and move to `async` as a result. Would be ideal to make a new snap of the library with the `lock` in place and include the update library here.