### PR TITLE
chore: update pyopensprinkler to 0.6.7

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -2,7 +2,7 @@
   "domain": "opensprinkler",
   "name": "OpenSprinkler",
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
-  "requirements": ["pyopensprinkler==0.6.6"],
+  "requirements": ["pyopensprinkler==0.6.7"],
   "dependencies": [],
   "codeowners": ["@vinteo"],
   "config_flow": true


### PR DESCRIPTION
Fixes: #89 , all timestamps should now be in UTC

Reference: https://github.com/vinteo/py-opensprinkler/pull/42