### PR TITLE
Friendly device info

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -129,12 +129,19 @@ class OpenSprinklerEntity(RestoreEntity):
 
         controller = self.hass.data[DOMAIN][self._entry.entry_id]["controller"]
 
+        model = controller.hardware_version_name or "Unknown"
+        if controller.hardware_type_name:
+            model += f" - ({controller.hardware_type_name})"
+
+        firmware = controller.firmware_version_name or "Unknown"
+        firmware += f" ({ controller.firmware_minor_version })"
+
         return {
             "identifiers": {(DOMAIN, slugify(self._entry.unique_id))},
             "name": self._name,
             "manufacturer": "OpenSprinkler",
-            "model": controller.hardware_version,
-            "sw_version": controller.firmware_version,
+            "model": model,
+            "sw_version": firmware,
         }
 
     @property

--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -2,7 +2,7 @@
   "domain": "opensprinkler",
   "name": "OpenSprinkler",
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
-  "requirements": ["pyopensprinkler==0.6.8"],
+  "requirements": ["pyopensprinkler==0.6.9"],
   "dependencies": [],
   "codeowners": ["@vinteo"],
   "config_flow": true


### PR DESCRIPTION
Provides for more user friendly `device_info` as below. **Note: Requires py-opensprinkler [PR47](https://github.com/vinteo/py-opensprinkler/pull/47)**

![image](https://user-images.githubusercontent.com/16738570/86510080-acf2ae00-bde4-11ea-9ef3-5592d493eb3f.png)