### PR TITLE
Re-assign controller attributes to relevant entities

### DIFF
--- a/custom_components/opensprinkler/binary_sensor.py
+++ b/custom_components/opensprinkler/binary_sensor.py
@@ -49,14 +49,14 @@ def _create_entities(hass: HomeAssistant, entry: dict):
     name = entry.data[CONF_NAME]
 
     entities.append(
-        ControllerSensorActive(entry, name, "sensor_1_active", controller, coordinator)
+        ControllerSensorActive(entry, name, "sensor_1", controller, coordinator)
     )
     entities.append(
-        ControllerSensorActive(entry, name, "sensor_2_active", controller, coordinator)
+        ControllerSensorActive(entry, name, "sensor_2", controller, coordinator)
     )
     entities.append(
         ControllerSensorActive(
-            entry, name, "rain_delay_active", controller, coordinator
+            entry, name, "rain_delay", controller, coordinator
         )
     )
 
@@ -74,12 +74,13 @@ class ControllerSensorActive(
 ):
     """Represent a sensor that for water level."""
 
-    def __init__(self, entry, name, attr, controller, coordinator):
+    def __init__(self, entry, name, sensor, controller, coordinator):
         """Set up a new opensprinkler water level sensor."""
         self._name = name
         self._controller = controller
         self._entity_type = "binary_sensor"
-        self._attr = attr
+        self._sensor = sensor
+        self._attr = sensor + "_active"
         super().__init__(entry, name, coordinator)
 
     @property
@@ -91,6 +92,17 @@ class ControllerSensorActive(
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entry.unique_id}_{self._entity_type}_{self._attr}")
+
+    @property
+    def device_state_attributes(self):
+        controller = self._controller
+        attributes = {}
+        try:
+            attributes[self._sensor + "_enabled"] = getattr(controller, self._sensor + "_enabled")
+        except:
+            pass
+
+        return attributes
 
     def _get_state(self) -> int:
         """Retrieve latest state."""

--- a/custom_components/opensprinkler/sensor.py
+++ b/custom_components/opensprinkler/sensor.py
@@ -89,6 +89,31 @@ class WaterLevelSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Entit
         """Return the units of measurement."""
         return "%"
 
+    @property
+    def device_state_attributes(self):
+        controller = self._controller
+        attributes = {}
+        for attr in [
+            "last_weather_call_error",
+            "last_weather_call_error_name",
+        ]:
+            try:
+                attributes[attr] = getattr(controller, attr)
+            except:
+                pass
+
+        for attr in [
+            "last_weather_call",
+            "last_successfull_weather_call",
+        ]:
+            timestamp = getattr(controller, attr)
+            if not timestamp:
+                attributes[attr] = None
+            else:
+                attributes[attr] = utc_from_timestamp(timestamp).isoformat()
+
+        return attributes
+
     def _get_state(self) -> int:
         """Retrieve latest state."""
         return self._controller.water_level
@@ -152,6 +177,22 @@ class LastRunSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Entity):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entry.unique_id}_{self._entity_type}_last_run")
+
+    @property
+    def device_state_attributes(self):
+        controller = self._controller
+        attributes = {}
+        for attr in [
+            "last_run_station",
+            "last_run_program",
+            "last_run_duration",
+        ]:
+            try:
+                attributes[attr] = getattr(controller, attr)
+            except:
+                pass
+
+        return attributes
 
     def _get_state(self):
         """Retrieve latest state."""

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -90,16 +90,6 @@ class ControllerOperationSwitch(
         controller = self._controller
         attributes = {"opensprinkler_type": "controller"}
         for attr in [
-            "firmware_version",
-            "hardware_version",
-            "hardware_type",
-            "last_run_station",
-            "last_run_program",
-            "last_run_duration",
-            "sensor_1_enabled",
-            "sensor_2_enabled",
-            "last_weather_call_error",
-            "last_weather_call_error_name",
             "last_reboot_cause",
             "last_reboot_cause_name",
         ]:
@@ -109,8 +99,6 @@ class ControllerOperationSwitch(
                 pass
 
         for attr in [
-            "last_weather_call",
-            "last_successfull_weather_call",
             "last_reboot_time",
         ]:
             timestamp = getattr(controller, attr)


### PR DESCRIPTION
Re-assign controller attributes to more relevant entities:
- `last_weather...` attributes assigned to `water_level` entity
- `last_run...` attributes assigned to `last_run` entity
- `sensor_X_enabled` assigned to `sensor_X_active` entity

Removed firmware/hardware attributes from controller as already present in `device_info`