### PR TITLE
feat: expose firmware version as device attribute

### DIFF
--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -77,6 +77,8 @@ class ControllerOperationSwitch(
         controller = self._controller
         attributes = {"opensprinkler_type": "controller"}
         for attr in [
+            "firmware_version",
+            "firmware_minor_version",
             "last_reboot_cause",
             "last_reboot_cause_name",
         ]:


### PR DESCRIPTION
This PR exposes the controller's firmware version as part of the device attributes of the controller operation switch; useful for inclusion within templates, automations and UI.