### PR TITLE
Add configuration url

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -187,6 +187,7 @@ class OpenSprinklerEntity(RestoreEntity):
             "identifiers": {(DOMAIN, slugify(self._entry.unique_id))},
             "name": self._name,
             "manufacturer": "OpenSprinkler",
+            "configuration_url":  f"http://{controller.ip_address}",            
             "model": model,
             "sw_version": firmware,
         }


### PR DESCRIPTION
Adding the configuration url allows to access the open sprinkler web frontend directly from homeassistant.