### PR TITLE
Bump pyopensprinkler to 0.7.6

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "opensprinkler",
   "name": "OpenSprinkler",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.4"],
+  "requirements": ["pyopensprinkler==0.7.6"],
   "dependencies": [],
   "codeowners": ["@vinteo"],
   "config_flow": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "OpenSprinkler integration for Home Assistant",
-  "homeassistant": "2021.12.0",
+  "homeassistant": "2023.3.0b0",
   "render_readme": true
 }


### PR DESCRIPTION
Only compatible with HA 2023.3.0b0 and up!

Closes #210 