### PR TITLE
Move name and description to translations

### DIFF
--- a/custom_components/opensprinkler/services.yaml
+++ b/custom_components/opensprinkler/services.yaml
@@ -1,26 +1,18 @@
 run:
-  description: Runs a controller program or station
   fields:
     entity_id:
-      description: Sensor or switch entity id for programs or stations
       example: "sensor.station_name"
     run_seconds:
-      description: Number of seconds to run (optional for stations, defaults to 60 seconds; required for controllers, list of seconds for each station or index and seconds pairs)
       example: 60
     continue_running_stations:
-      description: Keeps running stations that are not specified running (only used for controllers with index/second pairs, optional, defaults to False)
       example: False
 stop:
-  description: Stops a station or all station (for controller)
   fields:
     entity_id:
-      description: Sensor or switch entity id for stations or controller
       example: "sensor.station_name"
 set_water_level:
-  description: Set water level percentage
   fields:
     entity_id:
-      description: The water level entity to change
       example: "sensor.opensprinkler_water_level"
       required: true
       selector:
@@ -28,8 +20,6 @@ set_water_level:
           integration: opensprinkler
           domain: sensor
     water_level:
-      name: "Water level"
-      description: Percentage of water level
       example: 100
       required: true
       selector:
@@ -39,8 +29,6 @@ set_water_level:
           mode: slider
           unit_of_measurement: "%"
 reboot:
-  description: Reboot the controller
   fields:
     entity_id:
-      description: Switch entity id for controller
       example: "switch.opensprinkler_enabled"

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -21,5 +21,59 @@
       }
     }
   },
+  "services": {
+    "run": {
+      "name": "Run",
+      "description": "Runs a controller program or station.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Sensor or switch entity id for programs or stations."
+        },
+        "run_seconds": {
+          "name": "Run seconds",
+          "description": "Number of seconds to run (optional for stations, defaults to 60 seconds; required for controllers, list of seconds for each station or index and seconds pairs)."
+        },
+        "continue_running_stations": {
+          "name": "Continue running stations",
+          "description": "Keeps running stations that are not specified running (only used for controllers with index/second pairs, optional, defaults to False)."
+        }
+      }
+    },
+    "stop": {
+      "name": "Stop",
+      "description": "Stops a station or all station (for controller).",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Sensor or switch entity id for stations or controller."
+        }
+      }
+    },
+    "set_water_level": {
+      "name": "Set water level",
+      "description": "Set water level percentage.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The water level entity to change."
+        },
+        "water_level": {
+          "name": "Water level",
+          "description": "Percentage of water level."
+        }
+      }
+    },
+    "reboot": {
+      "name": "Reboot",
+      "description": "Reboot the controller.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id for controller."
+        }
+      }
+    }
+  },
   "title": "OpenSprinkler"
 }


### PR DESCRIPTION
Move service name and description strings to translations folder to support new "Translated services" feature in 2023.8.

Not sure that it's compatible with earlier versions of HA, but I believe the settings will stick until overridden, so probably only an issue for new installations of the integration.

Required change to satisfy "hassfest" Action.