### PR TITLE
chore-cleanup-translations

### DIFF
--- a/custom_components/opensprinkler/config_flow.py
+++ b/custom_components/opensprinkler/config_flow.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+from aiohttp.client_exceptions import InvalidURL
 from homeassistant import config_entries
 from homeassistant.const import CONF_MAC, CONF_NAME, CONF_PASSWORD, CONF_URL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -55,6 +56,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     title=name,
                     data={CONF_URL: url, CONF_PASSWORD: password, CONF_NAME: name},
                 )
+            except InvalidURL:
+                errors["base"] = "invalid_url"
             except OpenSprinklerConnectionError:
                 errors["base"] = "cannot_connect"
             except OpenSprinklerAuthError:

--- a/custom_components/opensprinkler/strings.json
+++ b/custom_components/opensprinkler/strings.json
@@ -1,25 +1,80 @@
 {
-  "title": "Connect to the OpenSprinkler controller",
+  "title": "OpenSprinkler",
   "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "invalid_url": "URL is malformed (example: http://192.168.0.1)",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "mac_address_required": "MAC Address required for firmware below 2.1.9 (4)",
+      "unknown": "Unexpected error"
+    },
     "step": {
       "user": {
-        "title": "Connect to the OpenSprinkler Controller",
         "data": {
           "url": "URL",
           "password": "Password",
           "mac": "MAC Address",
-          "name": "Device Name"
+          "name": "Controller Name"
+        },
+        "title": "Connect to the OpenSprinkler controller"
+      }
+    }
+  },
+  "services": {
+    "run": {
+      "name": "Run",
+      "description": "Runs a controller program or station.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Sensor or switch entity id for programs or stations."
+        },
+        "run_seconds": {
+          "name": "Run seconds",
+          "description": "Number of seconds to run (optional for stations, defaults to 60 seconds; required for controllers, list of seconds for each station or index and seconds pairs)."
+        },
+        "continue_running_stations": {
+          "name": "Continue running stations",
+          "description": "Keeps running stations that are not specified running (only used for controllers with index/second pairs, optional, defaults to False)."
         }
       }
     },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "mac_address_required": "MAC Address required for firmware below 2.1.9 (4)",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+    "stop": {
+      "name": "Stop",
+      "description": "Stops a station or all station (for controller).",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Sensor or switch entity id for stations or controller."
+        }
+      }
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    "set_water_level": {
+      "name": "Set water level",
+      "description": "Set water level percentage.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The water level entity to change."
+        },
+        "water_level": {
+          "name": "Water level",
+          "description": "Percentage of water level."
+        }
+      }
+    },
+    "reboot": {
+      "name": "Reboot",
+      "description": "Reboot the controller.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id for controller."
+        }
+      }
     }
   }
 }

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -1,21 +1,23 @@
 {
+  "title": "OpenSprinkler",
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "Device is already configured"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_url": "URL is malformed (example: http://192.168.0.1)",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
       "mac_address_required": "MAC Address required for firmware below 2.1.9 (4)",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
         "data": {
           "url": "URL",
-          "name": "Controller Name",
           "password": "Password",
-          "mac": "MAC Address"
+          "mac": "MAC Address",
+          "name": "Controller Name"
         },
         "title": "Connect to the OpenSprinkler controller"
       }
@@ -74,6 +76,5 @@
         }
       }
     }
-  },
-  "title": "OpenSprinkler"
+  }
 }


### PR DESCRIPTION
Cleanup of translations and minor adjustments. Looks worse than it is because strings.json was overwritten (and can be ignored).

1. While I couldn't find a definitive reference in the "official" docs, the consensus seems to be that strings.json should be exactly the same as the primary language in the translations folder, en.json. This is probably for backward compatibility, and the duplicate hopefully can eventually go away. Have copied en.json to strings.json.
2. Error strings do not get translated in non-core integrations. Converted them to the text in core: homeassistant/strings.json
3. Slightly out of scope, but errors for badly formatted URLs during config flow were falling thru to the generic Exception and getting displayed as "Unexpected exception". Now trap the aiohttp InvalidURL exception and display message showing example formatting.

Here's the existing behavior for a "cannot_connect" error, as in wrong IP address:

![NotTranslated](https://github.com/vinteo/hass-opensprinkler/assets/56356940/1fe09a21-63a0-4ea3-817e-b322c467db6d)

New behavior:

![FailedToConnect](https://github.com/vinteo/hass-opensprinkler/assets/56356940/33a0bc86-cacf-4c09-a427-d5f630862a61)

Also for invalid url formatting:

![URLIsMalformed](https://github.com/vinteo/hass-opensprinkler/assets/56356940/e9b51e72-c2fa-4bc0-a918-087f70d48e7b)

Finally, invalid authentication:

![InvalidAuthentication](https://github.com/vinteo/hass-opensprinkler/assets/56356940/a2f8211c-42cf-4d0d-a84d-f10330436fc3)

Let me know what you think.