### PR TITLE
chore-eliminate-hassfest-warning

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -39,11 +39,6 @@ PLATFORMS = ["binary_sensor", "number", "select", "sensor", "switch", "text", "t
 TIMEOUT = 10
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the openSprinkler component from YAML."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up OpenSprinkler from a config entry."""
     hass.data.setdefault(DOMAIN, {})


### PR DESCRIPTION
Addresses 2nd part of "Fix hassfest errors #237", the Warning:

[CONFIG_SCHEMA] Integrations which implement 'async_setup' or 'setup' must define either 'CONFIG_SCHEMA', 'PLATFORM_SCHEMA' or 'PLATFORM_SCHEMA_BASE'. If the integration has no configuration parameters, can only be set up from platforms or can only be set up from config entries, one of the helpers cv.empty_config_schema, cv.platform_only_config_schema or cv.config_entry_only_config_schema can be used.

May possibly address "Issue upgrading to Home Assistant Core 2023.8.0 #238". I don't use HACS, so don't know if it's still stuck at v1.1.15, but if it is, this could possibly be the cause, if the Warning above is the result of a new rule. Not sure when the rule was introduced or if Warnings prevent upgrades. Have no idea how that works, actually.

In any case, is it safe to assume that since we use Config Flow that we no longer support yaml configuration and also don't need async_setup?