### PR TITLE
fix-disable-current-time-by-default

### DIFF
--- a/custom_components/opensprinkler/sensor.py
+++ b/custom_components/opensprinkler/sensor.py
@@ -345,6 +345,11 @@ class ControllerCurrentTimeSensor(
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entry.unique_id}_{self._entity_type}_devt")
 
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
     def _get_state(self):
         """Retrieve latest state."""
         devt = self._controller.device_time


### PR DESCRIPTION
Disables `sensor.opensprinkler_current_time` by default. Addresses Issue #249.

Was planning to remove this entity and replace with a service, but now that it's released I think this is the way to go. Can still add a service later.

We don't need a constant update of the current time, but I have found it to wander in the past unexpectedly, so it's nice to have a way to check periodically.