### PR TITLE
feat-support-repeating-start-times

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.8"],
+  "requirements": ["pyopensprinkler==0.7.9"],
   "version": "1.2.3"
 }

--- a/custom_components/opensprinkler/number.py
+++ b/custom_components/opensprinkler/number.py
@@ -39,6 +39,12 @@ def _create_entities(hass: HomeAssistant, entry: dict):
     for _, program in controller.programs.items():
         entities.append(ProgramIntervalDaysNumber(entry, name, program, coordinator))
         entities.append(ProgramStartingInDaysNumber(entry, name, program, coordinator))
+        entities.append(
+            ProgramStartTimeRepeatCountNumber(entry, name, program, coordinator)
+        )
+        entities.append(
+            ProgramStartTimeRepeatIntervalNumber(entry, name, program, coordinator)
+        )
         for start_index in range(4):
             entities.append(
                 ProgramStartTimeOffsetNumber(
@@ -311,4 +317,127 @@ class ProgramStartTimeOffsetNumber(
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self._program.set_program_start_time_offset(self._start_index, int(value))
+        await self._coordinator.async_request_refresh()
+
+
+class ProgramStartTimeRepeatCountNumber(
+    OpenSprinklerProgramEntity, OpenSprinklerNumber, NumberEntity
+):
+    """Represent a number for Start Time Repeat Count of a program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program number for Start Time Repeat Count."""
+        self._program = program
+        self._entity_type = "number"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def name(self) -> str:
+        """Return the name of this number."""
+        return f"{self._program.name} Start Time Repeat Count"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_start_time_repeat_count_{self._program.index}"
+        )
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set disabled by default."""
+        return False
+
+    @property
+    def mode(self) -> str:
+        """Defines how the number should be displayed in the UI."""
+        return "auto"
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:repeat-variant"
+
+    @property
+    def native_max_value(self) -> float:
+        """The maximum accepted value."""
+        return 1440.0
+
+    @property
+    def native_min_value(self) -> float:
+        """The minimum accepted value."""
+        return 0.0
+
+    @property
+    def native_value(self) -> float:
+        """The value of the number."""
+        return self._program.program_start_repeat_count
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        await self._program.set_program_start_repeat_count(int(value))
+        await self._coordinator.async_request_refresh()
+
+
+class ProgramStartTimeRepeatIntervalNumber(
+    OpenSprinklerProgramEntity, OpenSprinklerNumber, NumberEntity
+):
+    """Represent a number for Start Time Repeat Interval in minutes of a program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program number for Start Time Repeat Interval."""
+        self._program = program
+        self._entity_type = "number"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def name(self) -> str:
+        """Return the name of this number."""
+        return f"{self._program.name} Start Time Repeat Interval"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_start_time_repeat_interval_{self._program.index}"
+        )
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set disabled by default."""
+        return False
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """The unit of measurement that the sensor's value is expressed in."""
+        return "min"
+
+    @property
+    def mode(self) -> str:
+        """Defines how the number should be displayed in the UI."""
+        return "auto"
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:clock-end"
+
+    @property
+    def native_max_value(self) -> float:
+        """The maximum accepted value in the number's native_unit_of_measurement."""
+        return 32767.0
+
+    @property
+    def native_min_value(self) -> float:
+        """The minimum accepted value in the number's native_unit_of_measurement."""
+        return 0.0
+
+    @property
+    def native_value(self) -> float:
+        """The value of the number in the number's native_unit_of_measurement."""
+        return self._program.program_start_repeat_interval
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        await self._program.set_program_start_repeat_interval(int(value))
         await self._coordinator.async_request_refresh()


### PR DESCRIPTION
Feature to complete support for `Additional Start Times`. Requires `py-opensprinkler v0.7.9`.

By using Conditional Cards, users can display the appropriate controls, depending on the `Start Time Type`:

![AdditonalStartTimes](https://github.com/vinteo/hass-opensprinkler/assets/56356940/7cd1e2d1-9940-4f38-a1bb-cda114f358f0)

Because data in the fields start1-3 is stored differently depending on the `Start Time Type`, these fields are cleared by `py-opensprinkler` whenever the type is changed.

The new entities for repeat count and interval are created `Disabled` to reduce entity bloat for those who do not use `Additional Start Times`.