### PR TITLE
feat-support-weekly-schedule

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.10"],
+  "requirements": ["pyopensprinkler==0.7.11"],
   "version": "1.2.4"
 }

--- a/custom_components/opensprinkler/number.py
+++ b/custom_components/opensprinkler/number.py
@@ -163,16 +163,16 @@ class ProgramIntervalDaysNumber(
     @property
     def native_min_value(self) -> float:
         """The minimum accepted value in the number's native_unit_of_measurement."""
-        return max(1.0, self._program.days0 + 1.0)
+        return max(1.0, self._program.starting_in_days + 1.0)
 
     @property
     def native_value(self) -> float:
         """The value of the number in the number's native_unit_of_measurement."""
-        return self._program.days1
+        return self._program.interval_days
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        await self._program.set_days1(round(value))
+        await self._program.set_interval_days(round(value))
         await self._coordinator.async_request_refresh()
 
 
@@ -217,7 +217,7 @@ class ProgramStartingInDaysNumber(
     @property
     def native_max_value(self) -> float:
         """The maximum accepted value in the number's native_unit_of_measurement."""
-        return self._program.days1 - 1.0
+        return self._program.interval_days - 1.0
 
     @property
     def native_min_value(self) -> float:
@@ -227,11 +227,11 @@ class ProgramStartingInDaysNumber(
     @property
     def native_value(self) -> float:
         """The value of the number in the number's native_unit_of_measurement."""
-        return self._program.days0
+        return self._program.starting_in_days
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        await self._program.set_days0(round(value))
+        await self._program.set_starting_in_days(round(value))
         await self._coordinator.async_request_refresh()
 
 

--- a/custom_components/opensprinkler/select.py
+++ b/custom_components/opensprinkler/select.py
@@ -138,21 +138,21 @@ class ProgramTypeSelect(OpenSprinklerProgramEntity, OpenSprinklerSelect, SelectE
     @property
     def options(self) -> list[str]:
         """A list of available options as strings"""
-        return ["Weekday", "Interval"]
+        return ["Weekly", "Interval"]
 
     @property
     def current_option(self) -> str:
         """The current select option"""
         match self._program.program_schedule_type:
             case 0:
-                return "Weekday"
+                return "Weekly"
             case 3:
                 return "Interval"
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         match option:
-            case "Weekday":
+            case "Weekly":
                 value = 0
             case "Interval":
                 value = 3


### PR DESCRIPTION
Fully support `Interval` vs. `Weekly` scheduling. Creates a new `switch` entity for each day of the week for each program. Entities are disabled by default to avoid entity bloat for those not using `Weekly` scheduling. Depends on `py-opensprinkler` PR https://github.com/vinteo/py-opensprinkler/pull/88.

This completes support for all features available on the older (pre `Date Range`) version of the `OpenSprinkler` `Edit Programs` web page.

A conditional card can be used to display only appropriate controls, depending on the `Program Type` currently selected, as shown here:

![CombinedProgramTypes](https://github.com/vinteo/hass-opensprinkler/assets/56356940/639537fb-e338-4f18-bb06-d270711afac9)
