### PR TITLE
Fix broken services in HA `2024.2.1`

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -44,6 +44,14 @@ PLATFORMS = ["binary_sensor", "number", "select", "sensor", "switch", "text", "t
 TIMEOUT = 10
 
 
+def async_get_entities(hass: HomeAssistant):
+    """Get entities for a domain."""
+    entities = {}
+    for platform in async_get_platforms(hass, DOMAIN):
+        entities.update(platform.entities)
+    return entities
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up OpenSprinkler from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -106,7 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Setup services
     async def _async_send_run_command(call: ServiceCall):
         await hass.helpers.service.entity_service_call(
-            async_get_platforms(hass, DOMAIN), SERVICE_RUN, call
+            async_get_entities(hass), SERVICE_RUN, call
         )
 
     hass.services.async_register(
@@ -118,7 +126,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def _async_send_stop_command(call: ServiceCall):
         await hass.helpers.service.entity_service_call(
-            async_get_platforms(hass, DOMAIN), SERVICE_STOP, call
+            async_get_entities(hass), SERVICE_STOP, call
         )
 
     hass.services.async_register(
@@ -130,7 +138,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def _async_send_set_water_level_command(call: ServiceCall):
         await hass.helpers.service.entity_service_call(
-            async_get_platforms(hass, DOMAIN), SERVICE_SET_WATER_LEVEL, call
+            async_get_entities(hass), SERVICE_SET_WATER_LEVEL, call
         )
 
     hass.services.async_register(
@@ -142,7 +150,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def _async_send_set_rain_delay_command(call: ServiceCall):
         await hass.helpers.service.entity_service_call(
-            async_get_platforms(hass, DOMAIN), SERVICE_SET_RAIN_DELAY, call
+            async_get_entities(hass), SERVICE_SET_RAIN_DELAY, call
         )
 
     hass.services.async_register(
@@ -154,7 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def _async_send_pause_stations_command(call: ServiceCall):
         await hass.helpers.service.entity_service_call(
-            async_get_platforms(hass, DOMAIN), SERVICE_PAUSE_STATIONS, call
+            async_get_entities(hass), SERVICE_PAUSE_STATIONS, call
         )
 
     hass.services.async_register(
@@ -166,7 +174,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def _async_send_reboot_command(call: ServiceCall):
         await hass.helpers.service.entity_service_call(
-            async_get_platforms(hass, DOMAIN), SERVICE_REBOOT, call
+            async_get_entities(hass), SERVICE_REBOOT, call
         )
 
     hass.services.async_register(


### PR DESCRIPTION
In Home Assistant `2024.2.1` this service is always erroring with:

```
Failed to call service opensprinkler/run. 'list' object has no attribute 'get'
```

The stacktrace for this error is below:

```
2024-02-10 12:46:23.684 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [<REDACTED>] 'list' object has no attribute 'get'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 240, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2279, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2316, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/opensprinkler/__init__.py", line 108, in _async_send_run_command
    await hass.helpers.service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 843, in entity_service_call
    entity_candidates = _get_permissible_entity_candidates(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 796, in _get_permissible_entity_candidates
    and (entity := entities.get(single_entity)) is not None
                   ^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```

After some investigation I found that the function signature for `entity_service_call` was changed in
https://github.com/home-assistant/core/pull/106759 from `Iterable[EntityPlatform]` to `dict[str, Entity]`.

It's not clear to me if this is some internal API that cannot be relied upon by custom components as it does not seem this was a widely communicated API change. But in any case it seems this change fixes the problem for me.

This new function `async_get_entities` was copied from a similar change in that PR except I removed the type signature because it required importing `Entity`.

Please let me know if there is a simpler way to fix this as I'm not adept at writing Python code.