### PR TITLE
Feat show valid service entities

### DIFF
--- a/custom_components/opensprinkler/services.yaml
+++ b/custom_components/opensprinkler/services.yaml
@@ -1,24 +1,31 @@
 run:
+  target:
+    entity:
+      device_class: 
+        - controller
+        - program
+        - station
+    device:
   fields:
-    entity_id:
-      example: "sensor.station_name"
     run_seconds:
       example: 60
     continue_running_stations:
       example: False
+
 stop:
-  fields:
-    entity_id:
-      example: "sensor.station_name"
+  target:
+    entity:
+      device_class: 
+        - controller
+        - station
+    device:
+
 set_water_level:
+  target:
+    entity:
+      device_class: controller
+    device:
   fields:
-    entity_id:
-      example: "sensor.opensprinkler_water_level"
-      required: true
-      selector:
-        entity:
-          integration: opensprinkler
-          domain: sensor
     water_level:
       example: 100
       required: true
@@ -28,15 +35,13 @@ set_water_level:
           max: 250
           mode: slider
           unit_of_measurement: "%"
+
 set_rain_delay:
+  target:
+    entity:
+      device_class: controller
+    device:
   fields:
-    entity_id:
-      example: "sensor.opensprinkler_rain_delay_stop_time"
-      required: true
-      selector:
-        entity:
-          integration: opensprinkler
-          domain: sensor
     rain_delay:
       example: 24
       required: true
@@ -46,15 +51,13 @@ set_rain_delay:
           max: 32767
           mode: slider
           unit_of_measurement: "h"
+
 pause_stations:
+  target:
+    entity:
+      device_class: controller
+    device:
   fields:
-    entity_id:
-      example: "sensor.opensprinkler_pause_end_time"
-      required: true
-      selector:
-        entity:
-          integration: opensprinkler
-          domain: sensor
     pause_duration:
       example: 600
       required: true
@@ -64,7 +67,9 @@ pause_stations:
           max: 86400
           mode: slider
           unit_of_measurement: "s"
+
 reboot:
-  fields:
-    entity_id:
-      example: "switch.opensprinkler_enabled"
+  target:
+    entity:
+      device_class: controller
+    device:

--- a/custom_components/opensprinkler/services.yaml
+++ b/custom_components/opensprinkler/services.yaml
@@ -9,8 +9,16 @@ run:
   fields:
     run_seconds:
       example: 60
+      selector:
+        number:
+          min: 0
+          max: 64800
+          mode: slider
+          unit_of_measurement: "s"
     continue_running_stations:
       example: False
+      selector:
+        boolean:
 
 stop:
   target:

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -82,6 +82,11 @@ class ControllerOperationSwitch(
         )
 
     @property
+    def device_class(self) -> str:
+        """Return device_class."""
+        return "controller"
+
+    @property
     def icon(self) -> str:
         """Return icon."""
         if self._controller.enabled:
@@ -150,6 +155,11 @@ class ProgramEnabledSwitch(
         return slugify(
             f"{self._entry.unique_id}_{self._entity_type}_program_enabled_{self._program.index}"
         )
+
+    @property
+    def device_class(self) -> str:
+        """Return device_class."""
+        return "program"
 
     @property
     def icon(self) -> str:
@@ -285,6 +295,11 @@ class StationEnabledSwitch(
         return slugify(
             f"{self._entry.unique_id}_{self._entity_type}_station_enabled_{self._station.index}"
         )
+
+    @property
+    def device_class(self) -> str:
+        """Return device_class."""
+        return "station"
 
     @property
     def icon(self) -> str:


### PR DESCRIPTION
Show only **valid** entities in the UI when configuring services. Fixes Issue #280 .

Services that affect the controller will list `switch.<controller>_enabled`.

Services that affect programs will list all `switch.<program>_program_enabled` entities.

Services that affect stations will list all `switch.<station>_station_enabled` entities.

Services that affect more than one of the above will list multiple types of entities.

The UI will not list values under `Choose area` or `Choose device`, as these would then select inappropriate entities for the service.

While other legitimate entities such as `sensor.<station>_station_status` could have also been listed, they provide no additional value and were left out to prevent clutter. However, nothing prevents a user from using these in `YAML`, so existing automations and scripts using these types of entities will continue to work.

services.yaml now uses the `target` keyword rather than `fields` to specify valid entities.

I've tested this against the examples in the docs, but additional testing by others would be appreciated.