### PR TITLE
fix: allow run_seconds to use int or str as keys

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -316,9 +316,12 @@ class OpenSprinklerControllerEntity:
         if isinstance(run_seconds, dict):
             run_seconds_list = []
             for _, station in self._controller.stations.items():
+                seconds = run_seconds.get(
+                    station.index, run_seconds.get(str(station.index))
+                )
                 run_seconds_list.append(
-                    run_seconds.get(str(station.index))
-                    if run_seconds.get(str(station.index)) is not None
+                    seconds
+                    if seconds is not None
                     else (0 if continue_running_stations else station.seconds_remaining)
                 )
             await self._controller.run_once_program(run_seconds_list)


### PR DESCRIPTION
This resolves Issue #284, which pointed out that one of the formats for creating template switches used in the examples no longer works.

Consider this snippet:

```
  run_seconds:
    0: 60
    1: 60
    2: 60
    3: 60
    4: 60
    5: 60
```

If this is called as part of `opensprinkler.run` from `Developer tools > Services`, the keys are converted to strings, which is what the code expects. However, if it is part of a template switch, they arrive as integers, which `dict.get()` interprets as a lookup failure and returns `None`. Ultimately, the run durations are set to 0.

This PR attempts to find both int and str keys. If you know of a better way to cover both cases than to use the `default` parameter of `dict.get()`, please speak up.