### PR TITLE
Add support for reauth flow

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import async_get_platforms

--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -8,6 +8,7 @@ import async_timeout
 from aiohttp.client_exceptions import InvalidURL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_URL,
@@ -32,6 +33,7 @@ from pyopensprinkler import OpenSprinklerAuthError, OpenSprinklerConnectionError
 from .const import (
     CONF_INDEX,
     CONF_RUN_SECONDS,
+    DEFAULT_NAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     SCHEMA_SERVICE_PAUSE_STATIONS,
@@ -69,53 +71,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     url = entry.data.get(CONF_URL)
     password = entry.data.get(CONF_PASSWORD)
     verify_ssl = entry.data.get(CONF_VERIFY_SSL)
-    try:
-        opts = {"session": async_get_clientsession(hass), "verify_ssl": verify_ssl}
-        controller = OpenSprinkler(url, password, opts)
-        controller.refresh_on_update = False
+    opts = {"session": async_get_clientsession(hass), "verify_ssl": verify_ssl}
 
-        async def async_update_data():
-            """Fetch data from OpenSprinkler."""
-            _LOGGER.debug("refreshing data")
-            async with async_timeout.timeout(TIMEOUT):
-                try:
-                    await controller.refresh()
-                except OpenSprinklerAuthError as e:
-                    # wrong password, tell user to re-enter the password
-                    raise ConfigEntryAuthFailed from e
-                except (
-                    InvalidURL,
-                    OpenSprinklerConnectionError,
-                ) as e:
-                    raise UpdateFailed from e
+    controller = OpenSprinkler(url, password, opts)
+    controller.refresh_on_update = False
 
-                if not controller._state:
-                    raise UpdateFailed("Error fetching OpenSprinkler state")
+    async def async_update_data():
+        """Fetch data from OpenSprinkler."""
+        _LOGGER.debug("refreshing data")
+        async with async_timeout.timeout(TIMEOUT):
+            try:
+                await controller.refresh()
+            except OpenSprinklerAuthError as e:
+                # wrong password, tell user to re-enter the password
+                _LOGGER.debug(f"auth failure: {e}")
+                raise ConfigEntryAuthFailed from e
+            except (
+                InvalidURL,
+                OpenSprinklerConnectionError,
+            ) as e:
+                raise UpdateFailed from e
 
-                return controller._state
+            if not controller._state:
+                raise UpdateFailed("Error fetching OpenSprinkler state")
 
-        scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        coordinator = DataUpdateCoordinator(
-            hass,
-            _LOGGER,
-            name="OpenSprinkler resource status",
-            update_method=async_update_data,
-            update_interval=timedelta(seconds=scan_interval),
-        )
+            return controller._state
 
-        # initial load before loading platforms
-        await coordinator.async_refresh()
-        if not coordinator.last_update_success:
-            raise ConfigEntryNotReady
+    scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=f"{entry.data.get(CONF_NAME, DEFAULT_NAME)} resource status",
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=scan_interval),
+    )
 
-        hass.data[DOMAIN][entry.entry_id] = {
-            "coordinator": coordinator,
-            "controller": controller,
-        }
+    # initial load before loading platforms
+    await coordinator.async_config_entry_first_refresh()
 
-    except (OpenSprinklerAuthError, OpenSprinklerConnectionError) as exc:
-        _LOGGER.error("Unable to connect to OpenSprinkler controller: %s", str(exc))
-        raise ConfigEntryNotReady
+    hass.data[DOMAIN][entry.entry_id] = {
+        "coordinator": coordinator,
+        "controller": controller,
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/opensprinkler/strings.json
+++ b/custom_components/opensprinkler/strings.json
@@ -21,6 +21,13 @@
           "name": "Controller Name"
         },
         "title": "Connect to the OpenSprinkler controller"
+      },
+      "reauth": {
+        "data": {
+          "url": "URL",
+          "password": "Password"
+        },
+        "title": "Enter new password"
       }
     }
   },

--- a/custom_components/opensprinkler/strings.json
+++ b/custom_components/opensprinkler/strings.json
@@ -2,7 +2,8 @@
   "title": "OpenSprinkler",
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
     },
     "error": {
       "invalid_url": "URL is malformed (example: http://192.168.0.1)",

--- a/custom_components/opensprinkler/translations/de.json
+++ b/custom_components/opensprinkler/translations/de.json
@@ -20,6 +20,13 @@
           "name": "Controller Name"
         },
         "title": "Stellen Sie eine Verbindung zum OpenSprinkler-Controller her"
+      },
+      "reauth": {
+        "data": {
+          "url": "URL",
+          "password": "Passwort"
+        },
+        "title": "Neues Passwort eingeben"
       }
     }
   },

--- a/custom_components/opensprinkler/translations/de.json
+++ b/custom_components/opensprinkler/translations/de.json
@@ -2,7 +2,8 @@
   "title": "OpenSprinkler",
   "config": {
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert"
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "reauth_successful": "Die erneute Authentifizierung war erfolgreich"
     },
     "error": {
       "invalid_url": "URL ist ungültig (Beispiel: http://192.168.0.1)",

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -21,6 +21,13 @@
           "name": "Controller Name"
         },
         "title": "Connect to the OpenSprinkler controller"
+      },
+      "reauth": {
+        "data": {
+          "url": "URL",
+          "password": "Password"
+        },
+        "title": "Enter new password"
       }
     }
   },
@@ -91,7 +98,7 @@
         },
         "pause_duration": {
           "name": "Pause duration",
-          "description": "Pause duration in seconds."
+          "description": "Duration to pause in seconds."
         }
       }
     },

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -2,7 +2,8 @@
   "title": "OpenSprinkler",
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
     },
     "error": {
       "invalid_url": "URL is malformed (example: http://192.168.0.1)",

--- a/custom_components/opensprinkler/translations/sk.json
+++ b/custom_components/opensprinkler/translations/sk.json
@@ -2,7 +2,8 @@
   "title": "OpenSprinkler",
   "config": {
     "abort": {
-      "already_configured": "Zariadenie je už nakonfigurované"
+      "already_configured": "Zariadenie je už nakonfigurované",
+      "reauth_successful": "Opätovné overenie bolo úspešné"
     },
     "error": {
       "invalid_url": "Adresa URL má nesprávny tvar (príklad: http://192.168.0.1)",

--- a/custom_components/opensprinkler/translations/sk.json
+++ b/custom_components/opensprinkler/translations/sk.json
@@ -21,6 +21,13 @@
           "name": "Názov ovládača"
         },
         "title": "Pripojte sa k ovládaču OpenSprinkler"
+      },
+      "reauth": {
+        "data": {
+          "url": "URL",
+          "password": "Heslo"
+        },
+        "title": "Zadajte nové heslo"
       }
     }
   },


### PR DESCRIPTION
With https://github.com/vinteo/hass-opensprinkler/pull/298 merged, we should also add support for the reauthentication flow.

This PR also simplifies exception management on initial poll, by using HA's built-in `async_config_entry_first_refresh()` function.
It will automatically raise `ConfigEntryNotReady` when an error occurs. This allows us to remove a big `try:` block.