### PR TITLE
Addresses issue #304 deprecated_has_helpers_service

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.service import entity_service_call
 from homeassistant.helpers.update_coordinator import (
     ConfigEntryAuthFailed,
     DataUpdateCoordinator,
@@ -117,7 +118,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Setup services
     async def _async_send_run_command(call: ServiceCall):
-        await hass.helpers.service.entity_service_call(
+        await entity_service_call(
+            hass,
             async_get_entities(hass), SERVICE_RUN, call
         )
 
@@ -129,7 +131,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     async def _async_send_stop_command(call: ServiceCall):
-        await hass.helpers.service.entity_service_call(
+        await entity_service_call(
+            hass,
             async_get_entities(hass), SERVICE_STOP, call
         )
 
@@ -141,7 +144,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     async def _async_send_set_water_level_command(call: ServiceCall):
-        await hass.helpers.service.entity_service_call(
+        await entity_service_call(
+            hass,
             async_get_entities(hass), SERVICE_SET_WATER_LEVEL, call
         )
 
@@ -153,7 +157,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     async def _async_send_set_rain_delay_command(call: ServiceCall):
-        await hass.helpers.service.entity_service_call(
+        await entity_service_call(
+            hass,
             async_get_entities(hass), SERVICE_SET_RAIN_DELAY, call
         )
 
@@ -165,7 +170,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     async def _async_send_pause_stations_command(call: ServiceCall):
-        await hass.helpers.service.entity_service_call(
+        await entity_service_call(
+            hass,
             async_get_entities(hass), SERVICE_PAUSE_STATIONS, call
         )
 
@@ -177,7 +183,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     async def _async_send_reboot_command(call: ServiceCall):
-        await hass.helpers.service.entity_service_call(
+        await entity_service_call(
+            hass,
             async_get_entities(hass), SERVICE_REBOOT, call
         )
 

--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_URL,
     CONF_VERIFY_SSL,
 )
+
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -117,10 +118,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Setup services
-    async def _async_send_run_command(call: ServiceCall):
+    async def _async_send_run_command(call: ServiceCall) -> None:
         await entity_service_call(
-            hass,
-            async_get_entities(hass), SERVICE_RUN, call
+            hass, async_get_entities(hass), SERVICE_RUN, call, None
         )
 
     hass.services.async_register(
@@ -130,11 +130,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         service_func=_async_send_run_command,
     )
 
-    async def _async_send_stop_command(call: ServiceCall):
-        await entity_service_call(
-            hass,
-            async_get_entities(hass), SERVICE_STOP, call
-        )
+    async def _async_send_stop_command(call: ServiceCall) -> None:
+        await entity_service_call(hass, async_get_entities(hass), SERVICE_STOP, call)
 
     hass.services.async_register(
         domain=DOMAIN,
@@ -143,10 +140,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         service_func=_async_send_stop_command,
     )
 
-    async def _async_send_set_water_level_command(call: ServiceCall):
+    async def _async_send_set_water_level_command(call: ServiceCall) -> None:
         await entity_service_call(
-            hass,
-            async_get_entities(hass), SERVICE_SET_WATER_LEVEL, call
+            hass, async_get_entities(hass), SERVICE_SET_WATER_LEVEL, call
         )
 
     hass.services.async_register(
@@ -156,10 +152,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         service_func=_async_send_set_water_level_command,
     )
 
-    async def _async_send_set_rain_delay_command(call: ServiceCall):
+    async def _async_send_set_rain_delay_command(call: ServiceCall) -> None:
         await entity_service_call(
-            hass,
-            async_get_entities(hass), SERVICE_SET_RAIN_DELAY, call
+            hass, async_get_entities(hass), SERVICE_SET_RAIN_DELAY, call
         )
 
     hass.services.async_register(
@@ -169,10 +164,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         service_func=_async_send_set_rain_delay_command,
     )
 
-    async def _async_send_pause_stations_command(call: ServiceCall):
+    async def _async_send_pause_stations_command(call: ServiceCall) -> None:
         await entity_service_call(
-            hass,
-            async_get_entities(hass), SERVICE_PAUSE_STATIONS, call
+            hass, async_get_entities(hass), SERVICE_PAUSE_STATIONS, call
         )
 
     hass.services.async_register(
@@ -182,11 +176,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         service_func=_async_send_pause_stations_command,
     )
 
-    async def _async_send_reboot_command(call: ServiceCall):
-        await entity_service_call(
-            hass,
-            async_get_entities(hass), SERVICE_REBOOT, call
-        )
+    async def _async_send_reboot_command(call: ServiceCall) -> None:
+        await entity_service_call(hass, async_get_entities(hass), SERVICE_REBOOT, call)
 
     hass.services.async_register(
         domain=DOMAIN,

--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_URL,
     CONF_VERIFY_SSL,
 )
-
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession


### PR DESCRIPTION
Changes call to entity_service_call to pass the hass as the first parameter and imports the proper package.