### PR TITLE
Split run services by target type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Note: _1.0.0 has major breaking changes, you will need to update any automations
 
 ## Using Actions
 
-Available actions are `opensprinkler.run_program`, `opensprinkler.run_station`, and `opensprinkler.run_once` 
+Available actions are `opensprinkler.run_program`, `opensprinkler.run_station`, and `opensprinkler.run_once`
 to start a program, station, or controller (multiple stations) respectively, and `opensprinkler.stop` to stop one or all stations.
 
-Note: The action `opensprinkler.run` is deprecated and will be removed in a future release. Please migrate to one of the above actions, 
+Note: The action `opensprinkler.run` is deprecated and will be removed in a future release. Please migrate to one of the above actions,
 which use the same parameters.
 
 ### Run Examples
@@ -83,7 +83,7 @@ target:
 
 #### Run Once Program Example
 
-To run a number of stations at once, use `opensprinkler.run_once`. The run seconds can either be a list of seconds per station 
+To run a number of stations at once, use `opensprinkler.run_once`. The run seconds can either be a list of seconds per station
 or a list or dict of index and seconds pairs.
 The following examples are all equivalent.
 
@@ -120,8 +120,8 @@ data:
     "2": 30
 ```
 
-Calling `opensprinkler.run_once` or `opensprinkler.run_program` will stop all other stations that are running. 
-When using `opensprinkler.run_once`, you can set `continue_running_stations` to true to allow the stations to 
+Calling `opensprinkler.run_once` or `opensprinkler.run_program` will stop all other stations that are running.
+When using `opensprinkler.run_once`, you can set `continue_running_stations` to true to allow the stations to
 continue running. This only works when specifying the run seconds in index/seconds pairs.
 
 ```yaml

--- a/custom_components/opensprinkler/const.py
+++ b/custom_components/opensprinkler/const.py
@@ -21,6 +21,7 @@ SCHEMA_SERVICE_RUN_SECONDS = {
     vol.Required(CONF_INDEX): cv.positive_int,
     vol.Required(CONF_RUN_SECONDS): cv.positive_int,
 }
+
 SCHEMA_SERVICE_RUN = {
     vol.Optional(CONF_RUN_SECONDS): vol.Or(
         cv.ensure_list(cv.positive_int),
@@ -30,6 +31,20 @@ SCHEMA_SERVICE_RUN = {
     ),
     vol.Optional(CONF_CONTINUE_RUNNING_STATIONS): cv.boolean,
 }
+
+SCHEMA_SERVICE_RUN_ONCE = {
+    vol.Required(CONF_RUN_SECONDS): vol.Or(
+        cv.ensure_list(cv.positive_int),
+        cv.ensure_list(SCHEMA_SERVICE_RUN_SECONDS),
+        vol.Schema({}, extra=vol.ALLOW_EXTRA),
+    ),
+    vol.Optional(CONF_CONTINUE_RUNNING_STATIONS): cv.boolean,
+}
+
+SCHEMA_SERVICE_RUN_PROGRAM = {}
+
+SCHEMA_SERVICE_RUN_STATION = {vol.Optional(CONF_RUN_SECONDS): cv.positive_int}
+
 SCHEMA_SERVICE_STOP = {}
 
 SCHEMA_SERVICE_SET_RAIN_DELAY = {
@@ -51,6 +66,9 @@ SCHEMA_SERVICE_PAUSE_STATIONS = {
 SCHEMA_SERVICE_REBOOT = {}
 
 SERVICE_RUN = "run"
+SERVICE_RUN_ONCE = "run_once"
+SERVICE_RUN_PROGRAM = "run_program"
+SERVICE_RUN_STATION = "run_station"
 SERVICE_STOP = "stop"
 SERVICE_SET_WATER_LEVEL = "set_water_level"
 SERVICE_REBOOT = "reboot"

--- a/custom_components/opensprinkler/services.yaml
+++ b/custom_components/opensprinkler/services.yaml
@@ -20,6 +20,45 @@ run:
       selector:
         boolean:
 
+run_once:
+  target:
+    entity:
+      device_class:
+        - controller
+    device:
+  fields:
+    run_seconds:
+      example: "0: 60"
+      selector:
+        object:
+    continue_running_stations:
+      example: False
+      selector:
+        boolean:
+
+run_program:
+  target:
+    entity:
+      device_class:
+        - program
+    device:
+
+run_station:
+  target:
+    entity:
+      device_class:
+        - station
+    device:
+  fields:
+    run_seconds:
+      example: 60
+      selector:
+        number:
+          min: 0
+          max: 64800
+          mode: slider
+          unit_of_measurement: "s"
+
 stop:
   target:
     entity:

--- a/custom_components/opensprinkler/strings.json
+++ b/custom_components/opensprinkler/strings.json
@@ -51,6 +51,48 @@
         }
       }
     },
+    "run_once": {
+      "name": "Run Once",
+      "description": "Runs a controller.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id for controller."
+        },
+        "run_seconds": {
+          "name": "Run seconds",
+          "description": "List of seconds for each station (e.g. '- 60'), or key/value pairs (e.g. '0: 60'). One per line. See documentation for details."
+        },
+        "continue_running_stations": {
+          "name": "Continue running stations",
+          "description": "Keeps running stations that are not specified (only used for controllers with index/seconds pairs, optional, defaults to False)."
+        }
+      }
+    },
+    "run_program": {
+      "name": "Run Program",
+      "description": "Runs a Program.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id of a program."
+        }
+      }
+    },
+    "run_station": {
+      "name": "Run Station",
+      "description": "Runs a Station for the specified number of seconds.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id of a station."
+        },
+        "run_seconds": {
+          "name": "Run seconds",
+          "description": "Number of seconds to run the station. Optional, defaults to 60 seconds."
+        }
+      }
+    },
     "stop": {
       "name": "Stop",
       "description": "Stops a station or all station (for controller).",

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -51,6 +51,48 @@
         }
       }
     },
+    "run_once": {
+      "name": "Run Once",
+      "description": "Runs a controller.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id for controller."
+        },
+        "run_seconds": {
+          "name": "Run seconds",
+          "description": "List of seconds for each station (e.g. '- 60'), or key/value pairs (e.g. '0: 60'). One per line. See documentation for details."
+        },
+        "continue_running_stations": {
+          "name": "Continue running stations",
+          "description": "Keeps running stations that are not specified (only used for controllers with index/seconds pairs, optional, defaults to False)."
+        }
+      }
+    },
+    "run_program": {
+      "name": "Run Program",
+      "description": "Runs a Program.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id of a program."
+        }
+      }
+    },
+    "run_station": {
+      "name": "Run Station",
+      "description": "Runs a Station for the specified number of seconds.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "Switch entity id of a station."
+        },
+        "run_seconds": {
+          "name": "Run seconds",
+          "description": "Number of seconds to run the station. Optional, defaults to 60 seconds."
+        }
+      }
+    },
     "stop": {
       "name": "Stop",
       "description": "Stops a station or all station (for controller).",


### PR DESCRIPTION
This is a continuation of an earlier effort to simplify and clarify action (service) calling. That effort limited the available entities presented by the UI to only those appropriate to the action. This PR was inspired by Issue #313 and is intended to reduce the available selection of parameters available in the UI to the `run` action depending on the use case.

It has become clear that the only way to effectively do this was to split the `run` action into multiple actions, one for each type of target entity. This is due to the fact that each entity type (controller, station, and program) takes a different set of parameters: `run_seconds` and `continue_running_stations`, only `run_seconds`, and no parameters, respectively.

Therefore, I have added these new actions:

- `run_once`
- `run_station`
- `run_program`

I have left the `run` service as-is (with one exception--see below), with the hope that it can be deprecated and removed in the future.

I also noticed that the logic for `continue_running_stations` was reversed, so that has been corrected. This could be considered a breaking change, but is the only one.

Finally, I have updated the docs (except for non-"en" translations), probably more than I had intended, but I wanted the existing examples to be consistent with the new ones.

I realize this is a bit to take in. Let me know your thoughts.