### PR TITLE
Assign entity categories and device classes

### DIFF
--- a/custom_components/opensprinkler/binary_sensor.py
+++ b/custom_components/opensprinkler/binary_sensor.py
@@ -3,7 +3,10 @@
 import logging
 from typing import Callable
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
@@ -116,6 +119,11 @@ class ProgramIsRunningBinarySensor(
         super().__init__(entry, name, coordinator)
 
     @property
+    def device_class(self):
+        """Return the device class."""
+        return BinarySensorDeviceClass.RUNNING
+
+    @property
     def name(self) -> str:
         """Return the name of this sensor."""
         return self._program.name + " Program Running"
@@ -150,6 +158,11 @@ class StationIsRunningBinarySensor(
         self._station = station
         self._entity_type = "binary_sensor"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return BinarySensorDeviceClass.RUNNING
 
     @property
     def name(self) -> str:

--- a/custom_components/opensprinkler/binary_sensor.py
+++ b/custom_components/opensprinkler/binary_sensor.py
@@ -63,10 +63,10 @@ def _create_entities(hass: HomeAssistant, entry: dict):
 class ControllerSensorActive(
     OpenSprinklerControllerEntity, OpenSprinklerBinarySensor, BinarySensorEntity
 ):
-    """Represent a sensor that for water level."""
+    """Represent a sensor for status of a controller sensor input."""
 
     def __init__(self, entry, name, sensor, controller, coordinator):
-        """Set up a new opensprinkler water level sensor."""
+        """Set up a new opensprinkler sensor."""
         self._name = name
         self._controller = controller
         self._entity_type = "binary_sensor"

--- a/custom_components/opensprinkler/binary_sensor.py
+++ b/custom_components/opensprinkler/binary_sensor.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
@@ -70,6 +70,11 @@ class ControllerSensorActive(
         self._sensor = sensor
         self._attr = sensor + "_active"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def name(self) -> str:
@@ -187,6 +192,11 @@ class PauseActiveBinarySensor(
         self._entity_type = "binary_sensor"
         self._controller = controller
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def name(self) -> str:

--- a/custom_components/opensprinkler/number.py
+++ b/custom_components/opensprinkler/number.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
@@ -69,6 +69,11 @@ class ProgramDurationNumber(
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
     def name(self) -> str:
         """Return the name of this sensor."""
         return f"{self._program.name} {self._station.name} Station Duration"
@@ -130,6 +135,11 @@ class ProgramIntervalDaysNumber(
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
     def name(self) -> str:
         """Return the name of this number."""
         return f"{self._program.name} Interval Days"
@@ -187,6 +197,11 @@ class ProgramStartingInDaysNumber(
         self._program = program
         self._entity_type = "number"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:
@@ -247,6 +262,11 @@ class ProgramStartTimeOffsetNumber(
         self._start_index = start_index
         self._entity_type = "number"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:
@@ -333,6 +353,11 @@ class ProgramStartTimeRepeatCountNumber(
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
     def name(self) -> str:
         """Return the name of this number."""
         return f"{self._program.name} Start Time Repeat Count"
@@ -390,6 +415,11 @@ class ProgramStartTimeRepeatIntervalNumber(
         self._program = program
         self._entity_type = "number"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:

--- a/custom_components/opensprinkler/number.py
+++ b/custom_components/opensprinkler/number.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Callable
 
-from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
@@ -74,6 +74,11 @@ class ProgramDurationNumber(
         return EntityCategory.CONFIG
 
     @property
+    def device_class(self):
+        """Return the device class."""
+        return NumberDeviceClass.DURATION
+
+    @property
     def name(self) -> str:
         """Return the name of this sensor."""
         return f"{self._program.name} {self._station.name} Station Duration"
@@ -140,6 +145,11 @@ class ProgramIntervalDaysNumber(
         return EntityCategory.CONFIG
 
     @property
+    def device_class(self):
+        """Return the device class."""
+        return NumberDeviceClass.DURATION
+
+    @property
     def name(self) -> str:
         """Return the name of this number."""
         return f"{self._program.name} Interval Days"
@@ -202,6 +212,11 @@ class ProgramStartingInDaysNumber(
     def entity_category(self):
         """Return the entity category."""
         return EntityCategory.CONFIG
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return NumberDeviceClass.DURATION
 
     @property
     def name(self) -> str:
@@ -267,6 +282,11 @@ class ProgramStartTimeOffsetNumber(
     def entity_category(self):
         """Return the entity category."""
         return EntityCategory.CONFIG
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return NumberDeviceClass.DURATION
 
     @property
     def name(self) -> str:
@@ -420,6 +440,11 @@ class ProgramStartTimeRepeatIntervalNumber(
     def entity_category(self):
         """Return the entity category."""
         return EntityCategory.CONFIG
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return NumberDeviceClass.DURATION
 
     @property
     def name(self) -> str:

--- a/custom_components/opensprinkler/select.py
+++ b/custom_components/opensprinkler/select.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
@@ -65,6 +65,11 @@ class ProgramRestrictionsSelect(
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
     def name(self) -> str:
         """Return the name of this select."""
         return f"{self._program.name} Restrictions"
@@ -120,6 +125,11 @@ class ProgramTypeSelect(OpenSprinklerProgramEntity, OpenSprinklerSelect, SelectE
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
     def name(self) -> str:
         """Return the name of this select."""
         return f"{self._program.name} Type"
@@ -171,6 +181,11 @@ class ProgramAdditionalStartTimeTypeSelect(
         self._program = program
         self._entity_type = "select"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:
@@ -225,6 +240,11 @@ class ProgramStartTimeOffsetTypeSelect(
         self._start_index = start_index
         self._entity_type = "select"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:

--- a/custom_components/opensprinkler/sensor.py
+++ b/custom_components/opensprinkler/sensor.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
@@ -60,6 +60,11 @@ class WaterLevelSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Entit
         self._controller = controller
         self._entity_type = "sensor"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def icon(self) -> str:
@@ -122,6 +127,11 @@ class FlowRateSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Entity)
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
+
+    @property
     def icon(self) -> str:
         """Return icon."""
         return "mdi:speedometer"
@@ -154,6 +164,11 @@ class LastRunSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Entity):
         self._controller = controller
         self._entity_type = "sensor"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def device_class(self):
@@ -214,6 +229,11 @@ class RainDelayStopTimeSensor(
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
+
+    @property
     def device_class(self):
         """Return the device class."""
         return SensorDeviceClass.TIMESTAMP
@@ -251,6 +271,11 @@ class PauseEndTimeSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Ent
         self._entity_type = "sensor"
         self._controller = controller
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def device_class(self):
@@ -291,6 +316,11 @@ class StationStatusSensor(OpenSprinklerStationEntity, OpenSprinklerSensor, Entit
         self._station = station
         self._entity_type = "sensor"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def name(self) -> str:
@@ -334,6 +364,11 @@ class CurrentDrawSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Enti
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
+
+    @property
     def icon(self) -> str:
         """Return icon."""
         return "mdi:meter-electric-outline"
@@ -368,6 +403,11 @@ class ControllerCurrentTimeSensor(
         self._controller = controller
         self._entity_type = "sensor"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def device_class(self):

--- a/custom_components/opensprinkler/sensor.py
+++ b/custom_components/opensprinkler/sensor.py
@@ -132,6 +132,11 @@ class FlowRateSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Entity)
         return EntityCategory.DIAGNOSTIC
 
     @property
+    def device_class(self):
+        """Return the device class."""
+        return SensorDeviceClass.VOLUME_FLOW_RATE
+
+    @property
     def icon(self) -> str:
         """Return icon."""
         return "mdi:speedometer"
@@ -323,6 +328,22 @@ class StationStatusSensor(OpenSprinklerStationEntity, OpenSprinklerSensor, Entit
         return EntityCategory.DIAGNOSTIC
 
     @property
+    def device_class(self):
+        return SensorDeviceClass.ENUM
+
+    @property
+    def options(self) -> list[str]:
+        """A list of available options as strings"""
+        return [
+            "idle",
+            "manual",
+            "master_engaged",
+            "once_program",
+            "program",
+            "waiting",
+        ]
+
+    @property
     def name(self) -> str:
         """Return the name of this sensor."""
         return self._station.name + " Station Status"
@@ -367,6 +388,10 @@ class CurrentDrawSensor(OpenSprinklerControllerEntity, OpenSprinklerSensor, Enti
     def entity_category(self):
         """Return the entity category."""
         return EntityCategory.DIAGNOSTIC
+
+    @property
+    def device_class(self):
+        return SensorDeviceClass.CURRENT
 
     @property
     def icon(self) -> str:

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -1,7 +1,7 @@
 from typing import Callable
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 from homeassistant.util.dt import utc_from_timestamp
@@ -195,6 +195,11 @@ class ProgramWeekdaySwitch(
         super().__init__(entry, name, coordinator)
 
     @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
     def name(self):
         """Return the name of the switch."""
         return self._program.name + f" {self._weekday} Enabled"
@@ -239,6 +244,11 @@ class ProgramUseWeatherSwitch(
         self._program = program
         self._entity_type = "switch"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self):

--- a/custom_components/opensprinkler/text.py
+++ b/custom_components/opensprinkler/text.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable
 
 from homeassistant.components.text import TextEntity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
@@ -45,6 +45,11 @@ class ProgramNameText(OpenSprinklerProgramEntity, OpenSprinklerText, TextEntity)
         self._program = program
         self._entity_type = "text"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:

--- a/custom_components/opensprinkler/time.py
+++ b/custom_components/opensprinkler/time.py
@@ -7,7 +7,7 @@ from math import trunc
 from typing import Callable
 
 from homeassistant.components.time import TimeEntity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
@@ -55,6 +55,11 @@ class ProgramStartTime(OpenSprinklerProgramEntity, OpenSprinklerTime, TimeEntity
         self._start_index = start_index
         self._entity_type = "time"
         super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
When I first added this integration I was a bit overwhelmed with the sheer number of entities that were added to my auto-generated default dashboard. This PR moves many of them to the config and diagnostic entity categories, as well as assigning some more device classes.

See also Integration Quality Rules:
- [Entities are assigned an appropriate EntityCategory](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/entity-category/)
- [Entities use device classes where possible](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/entity-device-class/)