### PR TITLE
Fix: Integration page hangs after HA 2025.10

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
   "requirements": ["pyopensprinkler==0.7.15"],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/custom_components/opensprinkler/number.py
+++ b/custom_components/opensprinkler/number.py
@@ -187,6 +187,11 @@ class ProgramIntervalDaysNumber(
         return max(1.0, self._program.starting_in_days + 1.0)
 
     @property
+    def native_step(self) -> float:
+        """Defines the resolution of the values, i.e. the smallest increment or decrement in the number's"""
+        return 1.0
+
+    @property
     def native_value(self) -> float:
         """The value of the number in the number's native_unit_of_measurement."""
         return self._program.interval_days
@@ -248,12 +253,17 @@ class ProgramStartingInDaysNumber(
     @property
     def native_max_value(self) -> float:
         """The maximum accepted value in the number's native_unit_of_measurement."""
-        return self._program.interval_days - 1.0
+        return max(0.0, float(self._program.interval_days) - 1.0)
 
     @property
     def native_min_value(self) -> float:
         """The minimum accepted value in the number's native_unit_of_measurement."""
         return 0.0
+
+    @property
+    def native_step(self) -> float:
+        """Defines the resolution of the values, i.e. the smallest increment or decrement in the number's"""
+        return 1.0
 
     @property
     def native_value(self) -> float:


### PR DESCRIPTION
Chrome and the Companion App hang when displaying the integration page for OpenSprinkler. In my case it appears that the `native_max_value` for `ProgramStartingInDaysNumber` was being calculated as -1, or less than the `native_min_value` of 0 for one of my inactive programs.

Resolves #339.

The version number in the manifest has been bumped and a release is necessary.