### PR TITLE
Tolerate transient OpenSprinkler update failures

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -61,6 +61,70 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["binary_sensor", "number", "select", "sensor", "switch", "text", "time"]
 TIMEOUT = 10
+MAX_CONSECUTIVE_UPDATE_FAILURES = 3
+
+
+class OpenSprinklerDataUpdater:
+    """Fetch OpenSprinkler data while tolerating brief communication failures."""
+
+    def __init__(self, controller: OpenSprinkler) -> None:
+        """Initialize the data updater."""
+        self._controller = controller
+        self._consecutive_update_failures = 0
+
+    def _can_reuse_previous_state(self, error: Exception) -> bool:
+        """Return whether cached state can be used after a transient failure."""
+        if not self._controller._state:
+            return False
+
+        self._consecutive_update_failures += 1
+
+        if self._consecutive_update_failures >= MAX_CONSECUTIVE_UPDATE_FAILURES:
+            return False
+
+        reason = str(error) or type(error).__name__
+        _LOGGER.debug(
+            "Using previous OpenSprinkler state after transient update failure "
+            "(%d/%d): %s",
+            self._consecutive_update_failures,
+            MAX_CONSECUTIVE_UPDATE_FAILURES,
+            reason,
+        )
+        return True
+
+    async def async_update_data(self):
+        """Fetch data from OpenSprinkler."""
+        _LOGGER.debug("refreshing data")
+
+        try:
+            async with async_timeout.timeout(TIMEOUT):
+                await self._controller.refresh()
+        except OpenSprinklerAuthError as e:
+            # Wrong password, tell the user to re-enter it immediately.
+            _LOGGER.debug(f"auth failure: {e}")
+            raise ConfigEntryAuthFailed from e
+        except InvalidURL as e:
+            raise UpdateFailed from e
+        except OpenSprinklerConnectionError as e:
+            if self._can_reuse_previous_state(e):
+                return self._controller._state
+            raise UpdateFailed from e
+        except asyncio.TimeoutError as e:
+            if self._can_reuse_previous_state(e):
+                return self._controller._state
+            raise
+
+        if not self._controller._state:
+            raise UpdateFailed("Error fetching OpenSprinkler state")
+
+        if self._consecutive_update_failures:
+            _LOGGER.debug(
+                "OpenSprinkler update recovered after %d transient failure(s)",
+                self._consecutive_update_failures,
+            )
+            self._consecutive_update_failures = 0
+
+        return self._controller._state
 
 
 def async_get_entities(hass: HomeAssistant):
@@ -82,34 +146,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     controller = OpenSprinkler(url, password, opts)
     controller.refresh_on_update = False
-
-    async def async_update_data():
-        """Fetch data from OpenSprinkler."""
-        _LOGGER.debug("refreshing data")
-        async with async_timeout.timeout(TIMEOUT):
-            try:
-                await controller.refresh()
-            except OpenSprinklerAuthError as e:
-                # wrong password, tell user to re-enter the password
-                _LOGGER.debug(f"auth failure: {e}")
-                raise ConfigEntryAuthFailed from e
-            except (
-                InvalidURL,
-                OpenSprinklerConnectionError,
-            ) as e:
-                raise UpdateFailed from e
-
-            if not controller._state:
-                raise UpdateFailed("Error fetching OpenSprinkler state")
-
-            return controller._state
+    updater = OpenSprinklerDataUpdater(controller)
 
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=f"{entry.data.get(CONF_NAME, DEFAULT_NAME)} resource status",
-        update_method=async_update_data,
+        update_method=updater.async_update_data,
         update_interval=timedelta(seconds=scan_interval),
     )
 

--- a/tests/test_update_failures.py
+++ b/tests/test_update_failures.py
@@ -1,0 +1,112 @@
+"""Tests for transient OpenSprinkler update failures."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp.client_exceptions import InvalidURL
+from homeassistant.helpers.update_coordinator import (
+    ConfigEntryAuthFailed,
+    UpdateFailed,
+)
+from opensprinkler import (
+    MAX_CONSECUTIVE_UPDATE_FAILURES,
+    OpenSprinklerDataUpdater,
+)
+from pyopensprinkler import OpenSprinklerAuthError, OpenSprinklerConnectionError
+
+
+class MockController:
+    """Mock OpenSprinkler controller."""
+
+    def __init__(self, state=None):
+        self._state = state
+        self.refresh = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_successful_update_returns_current_state():
+    """A successful refresh returns the current controller state."""
+    state = {"status": "current"}
+    controller = MockController(state)
+    updater = OpenSprinklerDataUpdater(controller)
+
+    assert await updater.async_update_data() is state
+
+
+@pytest.mark.asyncio
+async def test_timeout_without_cached_state_fails_immediately():
+    """The initial refresh must not hide a timeout when no state exists."""
+    controller = MockController()
+    controller.refresh.side_effect = asyncio.TimeoutError
+    updater = OpenSprinklerDataUpdater(controller)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await updater.async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_cached_state_is_used_until_third_consecutive_timeout():
+    """Two timeouts keep cached data available and the third is propagated."""
+    state = {"status": "cached"}
+    controller = MockController(state)
+    controller.refresh.side_effect = asyncio.TimeoutError
+    updater = OpenSprinklerDataUpdater(controller)
+
+    for _ in range(MAX_CONSECUTIVE_UPDATE_FAILURES - 1):
+        assert await updater.async_update_data() is state
+
+    with pytest.raises(asyncio.TimeoutError):
+        await updater.async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_successful_update_resets_failure_counter():
+    """A success makes the next transient timeout the first failure again."""
+    state = {"status": "cached"}
+    controller = MockController(state)
+    controller.refresh.side_effect = [asyncio.TimeoutError, None, asyncio.TimeoutError]
+    updater = OpenSprinklerDataUpdater(controller)
+
+    assert await updater.async_update_data() is state
+    assert await updater.async_update_data() is state
+    assert await updater.async_update_data() is state
+
+
+@pytest.mark.asyncio
+async def test_connection_errors_use_same_failure_threshold():
+    """Transient connection errors also keep cached data for two attempts."""
+    state = {"status": "cached"}
+    controller = MockController(state)
+    controller.refresh.side_effect = OpenSprinklerConnectionError(
+        "Cannot connect to controller"
+    )
+    updater = OpenSprinklerDataUpdater(controller)
+
+    for _ in range(MAX_CONSECUTIVE_UPDATE_FAILURES - 1):
+        assert await updater.async_update_data() is state
+
+    with pytest.raises(UpdateFailed):
+        await updater.async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_authentication_error_is_never_suppressed():
+    """Authentication errors trigger reauthentication even with cached state."""
+    controller = MockController({"status": "cached"})
+    controller.refresh.side_effect = OpenSprinklerAuthError("Invalid password")
+    updater = OpenSprinklerDataUpdater(controller)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await updater.async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_invalid_url_is_never_suppressed():
+    """Configuration errors are reported immediately."""
+    controller = MockController({"status": "cached"})
+    controller.refresh.side_effect = InvalidURL("Invalid URL")
+    updater = OpenSprinklerDataUpdater(controller)
+
+    with pytest.raises(UpdateFailed):
+        await updater.async_update_data()


### PR DESCRIPTION
## Summary

This PR improves the handling of temporary communication failures between Home Assistant and OpenSprinkler.

## Problem

The integration currently propagates every timeout or connection error to `DataUpdateCoordinator`.

Because OpenSprinkler controllers can occasionally take more than 10 seconds to respond, a single failed request immediately:

- creates an error in the Home Assistant logs;
- marks all OpenSprinkler entities as unavailable;
- creates unnecessary unavailable/available transitions when the next update succeeds.

Typical error:

```text
Timeout fetching OpenSprinkler resource status data