### PR TITLE
Feature: Support recently added scheduling features

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -59,7 +59,16 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["binary_sensor", "date", "number", "select", "sensor", "switch", "text", "time"]
+PLATFORMS = [
+    "binary_sensor",
+    "date",
+    "number",
+    "select",
+    "sensor",
+    "switch",
+    "text",
+    "time"
+]
 TIMEOUT = 10
 MAX_CONSECUTIVE_UPDATE_FAILURES = 3
 

--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -59,7 +59,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["binary_sensor", "number", "select", "sensor", "switch", "text", "time"]
+PLATFORMS = ["binary_sensor", "date", "number", "select", "sensor", "switch", "text", "time"]
 TIMEOUT = 10
 MAX_CONSECUTIVE_UPDATE_FAILURES = 3
 
@@ -353,6 +353,10 @@ class OpenSprinklerBinarySensor(OpenSprinklerEntity):
     def is_on(self):
         """Return true if the binary sensor is on."""
         return self._get_state()
+
+
+class OpenSprinklerDate(OpenSprinklerEntity):
+    """Define a generic OpenSprinkler date."""
 
 
 class OpenSprinklerSensor(OpenSprinklerEntity):

--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -67,7 +67,7 @@ PLATFORMS = [
     "sensor",
     "switch",
     "text",
-    "time"
+    "time",
 ]
 TIMEOUT = 10
 MAX_CONSECUTIVE_UPDATE_FAILURES = 3

--- a/custom_components/opensprinkler/date.py
+++ b/custom_components/opensprinkler/date.py
@@ -9,7 +9,7 @@ from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
-from . import OpenSprinklerProgramEntity, OpenSprinklerDate
+from . import OpenSprinklerDate, OpenSprinklerProgramEntity
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/opensprinkler/date.py
+++ b/custom_components/opensprinkler/date.py
@@ -1,9 +1,7 @@
 """Component providing support for OpenSprinkler date entities."""
 
-import datetime
 import logging
 from datetime import date, timedelta
-from math import trunc
 from typing import Callable
 
 from homeassistant.components.date import DateEntity
@@ -42,7 +40,9 @@ def _create_entities(hass: HomeAssistant, entry: dict):
     return entities
 
 
-class ProgramSingleRunStartDate(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity):
+class ProgramSingleRunStartDate(
+    OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity
+):
     """Represent date for the start date of a Single-run program."""
 
     def __init__(self, entry, name, program, coordinator):
@@ -64,7 +64,9 @@ class ProgramSingleRunStartDate(OpenSprinklerProgramEntity, OpenSprinklerDate, D
     @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
-        return slugify(f"{self._entry.unique_id}_{self._entity_type}_single_run_start_date_{self._program.index}")
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_single_run_start_date_{self._program.index}"
+        )
 
     @property
     def icon(self) -> str:
@@ -75,10 +77,10 @@ class ProgramSingleRunStartDate(OpenSprinklerProgramEntity, OpenSprinklerDate, D
     def native_value(self) -> date:
         """The value of the date."""
         epoch_start = date(1970, 1, 1)
-        if self._program.program_schedule_type == 1: # Single-run program
-          return epoch_start + timedelta(days=self._program.single_run_day)
+        if self._program.program_schedule_type == 1:  # Single-run program
+            return epoch_start + timedelta(days=self._program.single_run_day)
         else:
-          return epoch_start
+            return epoch_start
 
     async def async_set_value(self, value: date) -> None:
         """Update the current value."""
@@ -86,6 +88,7 @@ class ProgramSingleRunStartDate(OpenSprinklerProgramEntity, OpenSprinklerDate, D
         days_since_epoch = (value - epoch_start).days
         await self._program.set_single_run_day(days_since_epoch)
         await self._coordinator.async_request_refresh()
+
 
 class ProgramDateRangeFrom(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity):
     """Represent date for the date range start date of a program."""
@@ -109,7 +112,9 @@ class ProgramDateRangeFrom(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEn
     @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
-        return slugify(f"{self._entry.unique_id}_{self._entity_type}_date_range_from_date_{self._program.index}")
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_date_range_from_date_{self._program.index}"
+        )
 
     @property
     def icon(self) -> str:
@@ -126,6 +131,7 @@ class ProgramDateRangeFrom(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEn
         """Update the current value."""
         await self._program.set_date_range_from(value.month, value.day)
         await self._coordinator.async_request_refresh()
+
 
 class ProgramDateRangeTo(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity):
     """Represent date for the date range end date of a program."""
@@ -149,7 +155,9 @@ class ProgramDateRangeTo(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEnti
     @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
-        return slugify(f"{self._entry.unique_id}_{self._entity_type}_date_range_to_date_{self._program.index}")
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_date_range_to_date_{self._program.index}"
+        )
 
     @property
     def icon(self) -> str:

--- a/custom_components/opensprinkler/date.py
+++ b/custom_components/opensprinkler/date.py
@@ -1,0 +1,168 @@
+"""Component providing support for OpenSprinkler date entities."""
+
+import datetime
+import logging
+from datetime import date, timedelta
+from math import trunc
+from typing import Callable
+
+from homeassistant.components.date import DateEntity
+from homeassistant.const import CONF_NAME, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
+
+from . import OpenSprinklerProgramEntity, OpenSprinklerDate
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: dict,
+    async_add_entities: Callable,
+):
+    """Set up the OpenSprinkler dates."""
+    entities = _create_entities(hass, entry)
+    async_add_entities(entities)
+
+
+def _create_entities(hass: HomeAssistant, entry: dict):
+    entities = []
+
+    controller = hass.data[DOMAIN][entry.entry_id]["controller"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    name = entry.data[CONF_NAME]
+
+    for _, program in controller.programs.items():
+        entities.append(ProgramSingleRunStartDate(entry, name, program, coordinator))
+        entities.append(ProgramDateRangeFrom(entry, name, program, coordinator))
+        entities.append(ProgramDateRangeTo(entry, name, program, coordinator))
+
+    return entities
+
+
+class ProgramSingleRunStartDate(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity):
+    """Represent date for the start date of a Single-run program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program date for a Single-run program start day."""
+        self._program = program
+        self._entity_type = "date"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
+    def name(self) -> str:
+        """Return the name of this date."""
+        return f"{self._program.name} Single-run Start Date"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(f"{self._entry.unique_id}_{self._entity_type}_single_run_start_date_{self._program.index}")
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:calendar"
+
+    @property
+    def native_value(self) -> date:
+        """The value of the date."""
+        epoch_start = date(1970, 1, 1)
+        if self._program.program_schedule_type == 1: # Single-run program
+          return epoch_start + timedelta(days=self._program.single_run_day)
+        else:
+          return epoch_start
+
+    async def async_set_value(self, value: date) -> None:
+        """Update the current value."""
+        epoch_start = date(1970, 1, 1)
+        days_since_epoch = (value - epoch_start).days
+        await self._program.set_single_run_day(days_since_epoch)
+        await self._coordinator.async_request_refresh()
+
+class ProgramDateRangeFrom(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity):
+    """Represent date for the date range start date of a program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program date for a program date range start date."""
+        self._program = program
+        self._entity_type = "date"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
+    def name(self) -> str:
+        """Return the name of this date."""
+        return f"{self._program.name} Date Range From Date"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(f"{self._entry.unique_id}_{self._entity_type}_date_range_from_date_{self._program.index}")
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:calendar-start"
+
+    @property
+    def native_value(self) -> date:
+        """The value of the date."""
+        from_date = self._program.date_range_from
+        return date.today().replace(month=from_date[0], day=from_date[1])
+
+    async def async_set_value(self, value: date) -> None:
+        """Update the current value."""
+        await self._program.set_date_range_from(value.month, value.day)
+        await self._coordinator.async_request_refresh()
+
+class ProgramDateRangeTo(OpenSprinklerProgramEntity, OpenSprinklerDate, DateEntity):
+    """Represent date for the date range end date of a program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program date for a program date range end date."""
+        self._program = program
+        self._entity_type = "date"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
+    def name(self) -> str:
+        """Return the name of this date."""
+        return f"{self._program.name} Date Range To Date"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(f"{self._entry.unique_id}_{self._entity_type}_date_range_to_date_{self._program.index}")
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:calendar-end"
+
+    @property
+    def native_value(self) -> date:
+        """The value of the date."""
+        to_date = self._program.date_range_to
+        return date.today().replace(month=to_date[0], day=to_date[1])
+
+    async def async_set_value(self, value: date) -> None:
+        """Update the current value."""
+        await self._program.set_date_range_to(value.month, value.day)
+        await self._coordinator.async_request_refresh()

--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.17"],
-  "version": "1.5.6"
+  "requirements": ["pyopensprinkler==0.7.18"],
+  "version": "1.6.0"
 }

--- a/custom_components/opensprinkler/number.py
+++ b/custom_components/opensprinkler/number.py
@@ -40,6 +40,7 @@ def _create_entities(hass: HomeAssistant, entry: dict):
     for _, program in controller.programs.items():
         entities.append(ProgramIntervalDaysNumber(entry, name, program, coordinator))
         entities.append(ProgramStartingInDaysNumber(entry, name, program, coordinator))
+        entities.append(ProgramDayofMonthNumber(entry, name, program, coordinator))
         entities.append(
             ProgramStartTimeRepeatCountNumber(entry, name, program, coordinator)
         )
@@ -131,7 +132,7 @@ class ProgramDurationNumber(
 class ProgramIntervalDaysNumber(
     OpenSprinklerProgramEntity, OpenSprinklerNumber, NumberEntity
 ):
-    """Represent a number for Interval Days of a program."""
+    """Represent a number for Interval Days of an Interval-day program."""
 
     def __init__(self, entry, name, program, coordinator):
         """Set up a new OpenSprinkler program number for Interval Days."""
@@ -205,7 +206,7 @@ class ProgramIntervalDaysNumber(
 class ProgramStartingInDaysNumber(
     OpenSprinklerProgramEntity, OpenSprinklerNumber, NumberEntity
 ):
-    """Represent a number for Starting In Days of a program."""
+    """Represent a number for Starting In Days of an Interval-day program."""
 
     def __init__(self, entry, name, program, coordinator):
         """Set up a new OpenSprinkler program number for Starting In Days."""
@@ -273,6 +274,80 @@ class ProgramStartingInDaysNumber(
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self._program.set_starting_in_days(round(value))
+        await self._coordinator.async_request_refresh()
+
+
+class ProgramDayofMonthNumber(
+    OpenSprinklerProgramEntity, OpenSprinklerNumber, NumberEntity
+):
+    """Represent a number for Day of Month of a Monthly program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program number for Day of Month."""
+        self._program = program
+        self._entity_type = "number"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return NumberDeviceClass.DURATION
+
+    @property
+    def name(self) -> str:
+        """Return the name of this number."""
+        return f"{self._program.name} Day of Month"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_day_of_month_{self._program.index}"
+        )
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """The unit of measurement that the sensor's value is expressed in."""
+        return "d"
+
+    @property
+    def mode(self) -> str:
+        """Defines how the number should be displayed in the UI."""
+        return "auto"
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:calendar-start"
+
+    @property
+    def native_max_value(self) -> float:
+        """The maximum accepted value in the number's native_unit_of_measurement."""
+        return 31.0
+
+    @property
+    def native_min_value(self) -> float:
+        """The minimum accepted value in the number's native_unit_of_measurement."""
+        return 0.0
+
+    @property
+    def native_step(self) -> float:
+        """Defines the resolution of the values, i.e. the smallest increment or decrement in the number's"""
+        return 1.0
+
+    @property
+    def native_value(self) -> float:
+        """The value of the number in the number's native_unit_of_measurement."""
+        return self._program.monthly_day
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        await self._program.set_monthly_day(round(value))
         await self._coordinator.async_request_refresh()
 
 

--- a/custom_components/opensprinkler/select.py
+++ b/custom_components/opensprinkler/select.py
@@ -149,7 +149,7 @@ class ProgramTypeSelect(OpenSprinklerProgramEntity, OpenSprinklerSelect, SelectE
     @property
     def options(self) -> list[str]:
         """A list of available options as strings"""
-        return ["Weekly", "Interval"]
+        return ["Weekly", "Single-run", "Monthly", "Interval"]
 
     @property
     def current_option(self) -> str:
@@ -157,6 +157,10 @@ class ProgramTypeSelect(OpenSprinklerProgramEntity, OpenSprinklerSelect, SelectE
         match self._program.program_schedule_type:
             case 0:
                 return "Weekly"
+            case 1:
+                return "Single-run"
+            case 2:
+                return "Monthly"
             case 3:
                 return "Interval"
 
@@ -165,6 +169,10 @@ class ProgramTypeSelect(OpenSprinklerProgramEntity, OpenSprinklerSelect, SelectE
         match option:
             case "Weekly":
                 value = 0
+            case "Single-run":
+                value = 1
+            case "Monthly":
+                value = 2
             case "Interval":
                 value = 3
         await self._program.set_program_schedule_type(value)

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -289,6 +289,7 @@ class ProgramUseWeatherSwitch(
         await self._program.set_use_weather_adjustments(0)
         await self._coordinator.async_request_refresh()
 
+
 class ProgramEnableDateRange(
     OpenSprinklerProgramEntity, OpenSprinklerBinarySensor, SwitchEntity
 ):

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -119,7 +119,7 @@ class ControllerOperationSwitch(
 
         return attributes
 
-    def _get_state(self) -> str:
+    def _get_state(self) -> bool:
         """Retrieve latest state."""
         return bool(self._controller.enabled)
 
@@ -170,7 +170,7 @@ class ProgramEnabledSwitch(
 
         return "mdi:calendar-remove"
 
-    def _get_state(self) -> str:
+    def _get_state(self) -> bool:
         """Retrieve latest state."""
         return bool(self._program.enabled)
 
@@ -323,7 +323,7 @@ class ProgramEnableDateRange(
         """Return icon."""
         return "mdi:calendar-range"
 
-    def _get_state(self) -> str:
+    def _get_state(self) -> bool:
         """Retrieve latest state."""
         return bool(self._program.date_range_enabled)
 

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -36,8 +36,8 @@ def _create_entities(hass: HomeAssistant, entry: dict):
 
     for _, program in controller.programs.items():
         entities.append(ProgramEnabledSwitch(entry, name, program, coordinator))
-
-    for _, program in controller.programs.items():
+        entities.append(ProgramUseWeatherSwitch(entry, name, program, coordinator))
+        entities.append(ProgramEnableDateRange(entry, name, program, coordinator))
         for weekday in [
             "Monday",
             "Tuesday",
@@ -51,9 +51,6 @@ def _create_entities(hass: HomeAssistant, entry: dict):
                 ProgramWeekdaySwitch(entry, name, program, weekday, coordinator)
             )
 
-    for _, program in controller.programs.items():
-        entities.append(ProgramUseWeatherSwitch(entry, name, program, coordinator))
-
     for _, station in controller.stations.items():
         entities.append(StationEnabledSwitch(entry, name, station, coordinator))
 
@@ -63,6 +60,8 @@ def _create_entities(hass: HomeAssistant, entry: dict):
 class ControllerOperationSwitch(
     OpenSprinklerControllerEntity, OpenSprinklerBinarySensor, SwitchEntity
 ):
+    """Represent a switch for enabling the controller."""
+
     def __init__(self, entry, name, controller, coordinator):
         """Set up a new OpenSprinkler controller switch."""
         self._controller = controller
@@ -138,6 +137,8 @@ class ControllerOperationSwitch(
 class ProgramEnabledSwitch(
     OpenSprinklerProgramEntity, OpenSprinklerBinarySensor, SwitchEntity
 ):
+    """Represent a switch for enabling a program."""
+
     def __init__(self, entry, name, program, coordinator):
         """Set up a new OpenSprinkler program switch."""
         self._program = program
@@ -187,6 +188,8 @@ class ProgramEnabledSwitch(
 class ProgramWeekdaySwitch(
     OpenSprinklerProgramEntity, OpenSprinklerBinarySensor, SwitchEntity
 ):
+    """Represent a switch for days of the week of a Weekly program."""
+
     def __init__(self, entry, name, program, weekday, coordinator):
         """Set up a new OpenSprinkler program weekday switch."""
         self._program = program
@@ -239,6 +242,8 @@ class ProgramWeekdaySwitch(
 class ProgramUseWeatherSwitch(
     OpenSprinklerProgramEntity, OpenSprinklerBinarySensor, SwitchEntity
 ):
+    """Represent a switch for using weather data for a program."""
+
     def __init__(self, entry, name, program, coordinator):
         """Set up a new OpenSprinkler program use weather switch."""
         self._program = program
@@ -284,10 +289,59 @@ class ProgramUseWeatherSwitch(
         await self._program.set_use_weather_adjustments(0)
         await self._coordinator.async_request_refresh()
 
+class ProgramEnableDateRange(
+    OpenSprinklerProgramEntity, OpenSprinklerBinarySensor, SwitchEntity
+):
+    """Represent a switch for restricting to a date range for a program."""
+
+    def __init__(self, entry, name, program, coordinator):
+        """Set up a new OpenSprinkler program enable date range switch."""
+        self._program = program
+        self._entity_type = "switch"
+        super().__init__(entry, name, coordinator)
+
+    @property
+    def entity_category(self):
+        """Return the entity category."""
+        return EntityCategory.CONFIG
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._program.name + " Enable Date Range"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return slugify(
+            f"{self._entry.unique_id}_{self._entity_type}_enable_date_range_{self._program.index}"
+        )
+
+    @property
+    def icon(self) -> str:
+        """Return icon."""
+        return "mdi:calendar-range"
+
+    def _get_state(self) -> str:
+        """Retrieve latest state."""
+        return bool(self._program.date_range_enabled)
+
+    async def async_turn_on(self, **kwargs):
+        """Enable the program."""
+        await self._program.set_date_range_flag(1)
+        await self._coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Disable the program."""
+        await self._program.set_date_range_flag(0)
+        await self._coordinator.async_request_refresh()
+
 
 class StationEnabledSwitch(
     OpenSprinklerStationEntity, OpenSprinklerBinarySensor, SwitchEntity
 ):
+    """Represent a switch for enabling a station."""
+
     def __init__(self, entry, name, station, coordinator):
         """Set up a new OpenSprinkler station switch."""
         self._station = station


### PR DESCRIPTION
Additional scheduling options have been added to the firmware in the last several releases. The `Single-run` and `Monthly` options share the same locations in the message structure with the currently supported `Weekly` and `Interval-day` options, and if these new options are chosen in the `OpenSprinkler` UI, the integration will not interpret the data correctly. This PR corrects this issue by adding support for all four scheduling options.

Also added is the ability to limit scheduling to a date range.

Part of the inspiration for this work is the intention of soon adding a reliable `Next Run` feature for each program and for the system as a whole. It is necessary for the integration to be aware of all possible scheduling parameters for this feature to be reliable.