### PR TITLE
Update manifest to use pyopensprinkler==0.7.19 - Prevent crashes on outdated firmware

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.18"],
+  "requirements": ["pyopensprinkler==0.7.19"],
   "version": "1.6.0"
 }


### PR DESCRIPTION
Updates to the `OpenSprinkler` firmware over the years have added new features. Some of these features use previously undefined bits in existing flags, while other updates add completely new fields to the messages. Attempting to access undefined bits in older firmware versions could lead to unexpected behavior, while attempting to access non-existent fields will cause serious exceptions.

This PR references `pyopensprinkler v0.7.19` which protects against both types of errors that could be caused by the most recently added features in `pyopensprinkler v0.7.18`.