### PR TITLE
Expose station group and controller station delay as attributes

### DIFF
--- a/custom_components/opensprinkler/__init__.py
+++ b/custom_components/opensprinkler/__init__.py
@@ -541,6 +541,7 @@ class OpenSprinklerStationEntity:
             "index",
             "is_master",
             "running_program_id",
+            "group",
         ]:
             try:
                 attributes[attr] = getattr(self._station, attr)

--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.19"],
+  "requirements": ["pyopensprinkler==0.7.20"],
   "version": "1.6.1"
 }

--- a/custom_components/opensprinkler/switch.py
+++ b/custom_components/opensprinkler/switch.py
@@ -102,6 +102,7 @@ class ControllerOperationSwitch(
             "firmware_minor_version",
             "last_reboot_cause",
             "last_reboot_cause_name",
+            "station_delay",
         ]:
             try:
                 attributes[attr] = getattr(controller, attr)

--- a/tests/test_station_attributes.py
+++ b/tests/test_station_attributes.py
@@ -1,0 +1,110 @@
+"""Tests for the station group and controller station delay attributes."""
+
+import sys
+
+
+class FirmwareNotSupportedError(Exception):
+    """Stand in for the library error raised by unsupported properties."""
+
+
+class MockStation:
+    """Mock station for testing."""
+
+    def __init__(self, group=0, group_supported=True):
+        self.name = "Front Lawn"
+        self.index = 0
+        self.is_master = False
+        self.running_program_id = 0
+        self.start_time = 0
+        self.end_time = 0
+        self._group = group
+        self._group_supported = group_supported
+
+    @property
+    def group(self):
+        if not self._group_supported:
+            raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
+        return self._group
+
+
+class MockController:
+    """Mock controller for testing."""
+
+    def __init__(self, station_delay=0):
+        self.firmware_version = 220
+        self.firmware_minor_version = 1
+        self.last_reboot_cause = 99
+        self.last_reboot_cause_name = "Reset button"
+        self.last_reboot_time = 0
+        self.station_delay = station_delay
+
+
+class MockCoordinator:
+    """Mock coordinator for testing."""
+
+    async def async_request_refresh(self):
+        pass
+
+
+def make_station_entity(station, coordinator):
+    sys.path.insert(0, "custom_components")
+    from opensprinkler import OpenSprinklerStationEntity
+
+    class TestEntity(OpenSprinklerStationEntity):
+        def __init__(self, station, coordinator):
+            self._station = station
+            self._coordinator = coordinator
+
+    return TestEntity(station, coordinator)
+
+
+def get_controller_switch_attributes(controller):
+    sys.path.insert(0, "custom_components")
+    from opensprinkler.switch import ControllerOperationSwitch
+
+    class Stub:
+        pass
+
+    stub = Stub()
+    stub._controller = controller
+
+    return ControllerOperationSwitch.extra_state_attributes.fget(stub)
+
+
+class TestStationGroupAttribute:
+    def test_group_is_exposed(self):
+        entity = make_station_entity(MockStation(group=3), MockCoordinator())
+        assert entity.extra_state_attributes["group"] == 3
+
+    def test_parallel_group_is_passed_through_unchanged(self):
+        entity = make_station_entity(MockStation(group=255), MockCoordinator())
+        assert entity.extra_state_attributes["group"] == 255
+
+    def test_group_omitted_on_unsupported_firmware(self):
+        """Older firmware raises, which must not take the other attributes with it."""
+        entity = make_station_entity(
+            MockStation(group_supported=False), MockCoordinator()
+        )
+        attributes = entity.extra_state_attributes
+        assert "group" not in attributes
+        assert attributes["index"] == 0
+        assert attributes["opensprinkler_type"] == "station"
+
+    def test_group_follows_the_station(self):
+        """Read per state write, not cached at setup, so a change is picked up."""
+        station = MockStation(group=0)
+        entity = make_station_entity(station, MockCoordinator())
+        assert entity.extra_state_attributes["group"] == 0
+        station._group = 1
+        assert entity.extra_state_attributes["group"] == 1
+
+
+class TestControllerStationDelayAttribute:
+    def test_station_delay_is_exposed(self):
+        attributes = get_controller_switch_attributes(MockController(station_delay=30))
+        assert attributes["station_delay"] == 30
+
+    def test_negative_station_delay_is_passed_through(self):
+        """Negative values mean stations overlap, and must not be clamped."""
+        attributes = get_controller_switch_attributes(MockController(station_delay=-15))
+        assert attributes["station_delay"] == -15


### PR DESCRIPTION
Station sequencing is not observable from Home Assistant today. Which stations serialize with each other, and which run concurrently, is decided by the station group id, and the gap the controller inserts between sequential stations is decided by the station delay option. Neither value reaches an entity, so an automation or an external scheduler cannot work out when a chain of stations will finish.

Changes:

- `manifest.json`: bump the requirement to `pyopensprinkler==0.7.20`, the release that added `Station.group` and `Controller.station_delay`. The `version` field is left alone.
- `OpenSprinklerStationEntity`: add `group` to the station attributes. The raw `stn_grp` id is passed through, so a consumer can compare two stations for membership of the same sequential group. 255 means the parallel group and is passed through as 255. A derived boolean was considered and rejected: stations in two different sequential groups also run concurrently, which a boolean cannot express.
- `ControllerOperationSwitch`: add `station_delay` to the controller attributes. Seconds, negative meaning stations overlap.

`Station.group` raises `FirmwareNotSupportedError` below firmware v2.2.0(1). The attribute is added to the existing per attribute try/except loop, so on older firmware the key is simply absent, exactly as other unsupported attributes already behave, and the rest of the entity's attributes are unaffected. `Controller.station_delay` needs no firmware gate and returns None when the option is missing.

Tests in `tests/test_station_attributes.py` cover the supported case, the parallel sentinel, omission of the key when the property raises, that a group change is reflected on the next state write rather than cached, and both signs of the station delay.