### PR TITLE
Fix calendar feature should support older firmware

### DIFF
--- a/custom_components/opensprinkler/calendar.py
+++ b/custom_components/opensprinkler/calendar.py
@@ -145,7 +145,9 @@ class OpenSprinklerCalendar(CalendarEntity):
                                         group = _station.group
                                     except FirmwareNotSupportedError:
                                         # Older firmware, 255->P, 0->A
-                                        group = 255 if _station.sequential_operation else 0
+                                        group = (
+                                            255 if _station.sequential_operation else 0
+                                        )
 
                                     stations.append(
                                         {

--- a/custom_components/opensprinkler/calendar.py
+++ b/custom_components/opensprinkler/calendar.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
+from pyopensprinkler.exceptions import FirmwareNotSupportedError
 from suntime import Sun
 
 from .const import (
@@ -136,12 +137,22 @@ class OpenSprinklerCalendar(CalendarEntity):
                             if _station.enabled:
                                 duration = _program.station_durations[_station.index]
                                 if duration > 0:
+
+                                    # Get group for sequential operations, depending on firmware version
+                                    group = None
+                                    try:
+                                        # Most recent firmware
+                                        group = _station.group
+                                    except FirmwareNotSupportedError:
+                                        # Older firmware, 255->P, 0->A
+                                        group = 255 if _station.sequential_operation else 0
+
                                     stations.append(
                                         {
                                             "station_name": _station.name,
                                             "duration": int(duration / 60),
                                             "rain_delay_ignored": _station.rain_delay_ignored,
-                                            "group": _station.group,
+                                            "group": group,
                                         }
                                     )
 

--- a/custom_components/opensprinkler/calendar.py
+++ b/custom_components/opensprinkler/calendar.py
@@ -144,9 +144,9 @@ class OpenSprinklerCalendar(CalendarEntity):
                                         # Most recent firmware
                                         group = _station.group
                                     except FirmwareNotSupportedError:
-                                        # Older firmware, 255->P, 0->A
+                                        # Older firmware, 0->A, 255->P
                                         group = (
-                                            255 if _station.sequential_operation else 0
+                                            0 if _station.sequential_operation else 255
                                         )
 
                                     stations.append(

--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
   "requirements": ["pyopensprinkler==0.7.20", "suntime==1.3.2"],
-  "version": "2.0.2"
+  "version": "2.0.3"
 }


### PR DESCRIPTION
Catches `FirmwareNotSupportedError` exception when attempting to get a station's `group` from older firmware that does not support groups. Falls back to use the older `sequential_operation` feature.

Closes #382.