### PR TITLE
Add Reconfigure flow to change controller URL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,28 @@ jobs:
       - name: Run tests
         run: |
           pytest tests/ -v --tb=short
+
+  test-ha-2024-11:
+    name: Home Assistant 2024.11 compatibility
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test-ha-2024.11.txt
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,9 +54,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install pinned test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-test-ha-2024.11.txt
+        # pyopensprinkler and mock-open (via pytest-homeassistant-custom-component)
+        # ship sdists only, so --only-binary :all: cannot be used here.
+        run: python -m pip install homeassistant==2024.11.0 pytest-homeassistant-custom-component==0.13.181 pyopensprinkler==0.7.20 josepy==1.14.0 # NOSONAR
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           pytest tests/ -v --tb=short
 
   test-ha-2024-11:
-    name: Home Assistant 2024.11 compatibility
+    name: Run Tests (HA 2024.11)
     runs-on: ubuntu-latest
 
     permissions:

--- a/README.md
+++ b/README.md
@@ -43,17 +43,11 @@ see the [OpenSprinkler Preview Card](https://github.com/EdLeckert/opensprinkler-
 
 If the OpenSprinkler IP address or hostname changes, do not remove the integration.
 
-1. Go to **Settings → Devices & services → OpenSprinkler**.
-2. Open the three-dot menu and choose **Reconfigure**.
-3. Enter the new controller URL, for example `http://192.168.1.50` or `http://opensprinkler.local`, and submit.
+1. In the Home Assistant UI, navigate to `Configuration` then `Integrations`.
+2. Select `OpenSprinkler` and choose `Reconfigure`.
+3. Enter the new URL (for example `http://192.168.0.1`) and save.
 
-The existing config entry, devices, and entities are kept.
-
-Simultaneous controller URL + password changes are unsupported in this PR; see Known Limitations.
-
-#### Known Limitations
-
-- Simultaneous controller URL + password changes are unsupported. Change the URL here only when the stored password still works at the new address.
+Existing devices and entities are kept. The stored password is used to connect to the new URL. Changing the URL and password at the same time is not supported.
 
 ### Upgrading from pre 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ see the [OpenSprinkler Preview Card](https://github.com/EdLeckert/opensprinkler-
    - MAC Address - MAC address of the device. This is only required for firmware below 2.1.9 (4), otherwise it can be left blank.
    - Controller Name - The name of the device that appears in Home Assistant.
 
+### Changing the controller URL
+
+If the OpenSprinkler IP address or hostname changes, do not remove the integration.
+
+1. Go to **Settings → Devices & services → OpenSprinkler**.
+2. Open the three-dot menu and choose **Reconfigure**.
+3. Enter the new controller URL, for example `http://192.168.1.50` or `http://opensprinkler.local`, and submit.
+
+The existing config entry, devices, and entities are kept.
+
+Simultaneous controller URL + password changes are unsupported in this PR; see Known Limitations.
+
+#### Known Limitations
+
+- Simultaneous controller URL + password changes are unsupported. Change the URL here only when the stored password still works at the new address.
+
 ### Upgrading from pre 1.0.0
 
 Note: _1.0.0 has major breaking changes, you will need to update any automations, scripts, etc_

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ see the [OpenSprinkler Preview Card](https://github.com/EdLeckert/opensprinkler-
 
 1. Install using [HACS](https://github.com/custom-components/hacs). Or install manually by copying `custom_components/opensprinkler` folder into `<config_dir>/custom_components`
 2. Restart Home Assistant.
-3. In the Home Assistant UI, navigate to `Configuration` then `Integrations`. Click on the add integration button at the bottom right and select `OpenSprinkler`. Fill out the options and save.
+3. In the Home Assistant UI, navigate to `Settings` then `Devices & services`. Click on the add integration button at the bottom right and select `OpenSprinkler`. Fill out the options and save.
    - URL - Should be in the form of `http://<ip or host>:<port>`. The port can be omitted unless you have changed it, as the default port for OpenSprinkler is `80`. SSL (HTTPS) is also supported.
    - Password - The OpenSprinkler controller password.
    - Verify SSL Certificate - If the integration should verify the certificate from an HTTPS server. Generally, this should be left checked.
@@ -43,7 +43,7 @@ see the [OpenSprinkler Preview Card](https://github.com/EdLeckert/opensprinkler-
 
 If the OpenSprinkler IP address or hostname changes, do not remove the integration.
 
-1. In the Home Assistant UI, navigate to `Configuration` then `Integrations`.
+1. In the Home Assistant UI, navigate to `Settings` then `Devices & services`.
 2. Select `OpenSprinkler` and choose `Reconfigure`.
 3. Enter the new URL (for example `http://192.168.0.1`) and save.
 

--- a/custom_components/opensprinkler/config_flow.py
+++ b/custom_components/opensprinkler/config_flow.py
@@ -147,14 +147,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_reconfigure(self, user_input=None):
-        """Handle reconfiguration of the controller URL."""
-        reconfigure_entry = self._get_reconfigure_entry()
-        errors = {}
+        """Handle reconfiguration."""
 
+        existing_entry = self._get_reconfigure_entry()
+        errors = {}
         if user_input is not None:
             url = user_input[CONF_URL]
             verify_ssl = user_input[CONF_VERIFY_SSL]
-            password = reconfigure_entry.data[CONF_PASSWORD]
+            password = existing_entry.data[CONF_PASSWORD]
             opts = {
                 "session": async_get_clientsession(self.hass),
                 "verify_ssl": verify_ssl,
@@ -173,8 +173,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                self._reconfigure_url = url
-                self._reconfigure_verify_ssl = verify_ssl
+                self.url = url
+                self.verify_ssl = verify_ssl
 
                 if controller.mac_address is None:
                     return await self.async_step_reconfigure_mac()
@@ -182,49 +182,51 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(slugify(controller.mac_address))
                 self._abort_if_unique_id_mismatch(reason="wrong_device")
                 return self.async_update_reload_and_abort(
-                    reconfigure_entry,
+                    existing_entry,
                     data_updates={
                         CONF_URL: url,
                         CONF_VERIFY_SSL: verify_ssl,
                     },
                 )
 
-        current_url = (user_input or {}).get(CONF_URL, reconfigure_entry.data[CONF_URL])
-        current_verify_ssl = (user_input or {}).get(
-            CONF_VERIFY_SSL,
-            reconfigure_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-        )
-
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_URL, default=current_url): str,
-                    vol.Required(CONF_VERIFY_SSL, default=current_verify_ssl): bool,
+                    vol.Required(CONF_URL, default=existing_entry.data[CONF_URL]): str,
+                    vol.Required(
+                        CONF_VERIFY_SSL,
+                        default=existing_entry.data.get(
+                            CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL
+                        ),
+                    ): bool,
                 }
             ),
             errors=errors,
         )
 
     async def async_step_reconfigure_mac(self, user_input=None):
-        """Confirm the controller MAC when the API does not return one."""
-        reconfigure_entry = self._get_reconfigure_entry()
-        errors = {}
+        """Handle reconfigure MAC."""
 
+        existing_entry = self._get_reconfigure_entry()
+        errors = {}
         if user_input is not None:
-            mac_address = user_input.get(CONF_MAC)
-            if not mac_address:
-                errors[CONF_MAC] = "mac_address_required"
-            else:
+            try:
+                mac_address = user_input.get(CONF_MAC)
+                if not mac_address:
+                    raise MacAddressRequiredError
+
                 await self.async_set_unique_id(slugify(mac_address))
                 self._abort_if_unique_id_mismatch(reason="wrong_device")
                 return self.async_update_reload_and_abort(
-                    reconfigure_entry,
+                    existing_entry,
                     data_updates={
-                        CONF_URL: self._reconfigure_url,
-                        CONF_VERIFY_SSL: self._reconfigure_verify_ssl,
+                        CONF_URL: self.url,
+                        CONF_VERIFY_SSL: self.verify_ssl,
                     },
                 )
+            except MacAddressRequiredError:
+                errors[CONF_MAC] = "mac_address_required"
 
         return self.async_show_form(
             step_id="reconfigure_mac",

--- a/custom_components/opensprinkler/config_flow.py
+++ b/custom_components/opensprinkler/config_flow.py
@@ -37,6 +37,11 @@ REAUTH_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
     }
 )
+RECONFIGURE_MAC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MAC): str,
+    }
+)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -139,6 +144,92 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth", data_schema=REAUTH_SCHEMA, errors=errors
+        )
+
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle reconfiguration of the controller URL."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors = {}
+
+        if user_input is not None:
+            url = user_input[CONF_URL]
+            verify_ssl = user_input[CONF_VERIFY_SSL]
+            password = reconfigure_entry.data[CONF_PASSWORD]
+            opts = {
+                "session": async_get_clientsession(self.hass),
+                "verify_ssl": verify_ssl,
+            }
+
+            try:
+                controller = OpenSprinkler(url, password, opts)
+                await controller.refresh()
+            except InvalidURL:
+                errors["base"] = "invalid_url"
+            except OpenSprinklerConnectionError:
+                errors["base"] = "cannot_connect"
+            except OpenSprinklerAuthError:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._reconfigure_url = url
+                self._reconfigure_verify_ssl = verify_ssl
+
+                if controller.mac_address is None:
+                    return await self.async_step_reconfigure_mac()
+
+                await self.async_set_unique_id(slugify(controller.mac_address))
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={
+                        CONF_URL: url,
+                        CONF_VERIFY_SSL: verify_ssl,
+                    },
+                )
+
+        current_url = (user_input or {}).get(CONF_URL, reconfigure_entry.data[CONF_URL])
+        current_verify_ssl = (user_input or {}).get(
+            CONF_VERIFY_SSL,
+            reconfigure_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_URL, default=current_url): str,
+                    vol.Required(CONF_VERIFY_SSL, default=current_verify_ssl): bool,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure_mac(self, user_input=None):
+        """Confirm the controller MAC when the API does not return one."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors = {}
+
+        if user_input is not None:
+            mac_address = user_input.get(CONF_MAC)
+            if not mac_address:
+                errors[CONF_MAC] = "mac_address_required"
+            else:
+                await self.async_set_unique_id(slugify(mac_address))
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={
+                        CONF_URL: self._reconfigure_url,
+                        CONF_VERIFY_SSL: self._reconfigure_verify_ssl,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure_mac",
+            data_schema=RECONFIGURE_MAC_SCHEMA,
+            errors=errors,
         )
 
 

--- a/custom_components/opensprinkler/strings.json
+++ b/custom_components/opensprinkler/strings.json
@@ -35,9 +35,10 @@
       "reconfigure": {
         "data": {
           "url": "URL",
-          "verify_ssl": "Verify SSL Certificate (Safer when checked)"
+          "verify_ssl": "Verify SSL certificate"
         },
-        "title": "Change the OpenSprinkler controller URL"
+        "description": "Enter the new controller URL. The stored password is used to connect.",
+        "title": "Reconfigure OpenSprinkler"
       },
       "reconfigure_mac": {
         "data": {

--- a/custom_components/opensprinkler/strings.json
+++ b/custom_components/opensprinkler/strings.json
@@ -3,7 +3,9 @@
   "config": {
     "abort": {
       "already_configured": "Device is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
+      "wrong_device": "This URL belongs to a different OpenSprinkler controller"
     },
     "error": {
       "invalid_url": "URL is malformed (example: http://192.168.0.1)",
@@ -29,6 +31,19 @@
           "password": "Password"
         },
         "title": "Enter new password"
+      },
+      "reconfigure": {
+        "data": {
+          "url": "URL",
+          "verify_ssl": "Verify SSL Certificate (Safer when checked)"
+        },
+        "title": "Change the OpenSprinkler controller URL"
+      },
+      "reconfigure_mac": {
+        "data": {
+          "mac": "MAC Address"
+        },
+        "title": "Confirm the OpenSprinkler MAC address"
       }
     }
   },

--- a/custom_components/opensprinkler/translations/de.json
+++ b/custom_components/opensprinkler/translations/de.json
@@ -34,9 +34,10 @@
       "reconfigure": {
         "data": {
           "url": "URL",
-          "verify_ssl": "SSL-Zertifikat prüfen (sicherer wenn aktiviert)"
+          "verify_ssl": "SSL-Zertifikat prüfen"
         },
-        "title": "OpenSprinkler-URL ändern"
+        "description": "Neue Controller-URL eingeben. Das gespeicherte Passwort wird zum Verbinden verwendet.",
+        "title": "OpenSprinkler neu konfigurieren"
       },
       "reconfigure_mac": {
         "data": {

--- a/custom_components/opensprinkler/translations/de.json
+++ b/custom_components/opensprinkler/translations/de.json
@@ -3,7 +3,9 @@
   "config": {
     "abort": {
       "already_configured": "Gerät ist bereits konfiguriert",
-      "reauth_successful": "Die erneute Authentifizierung war erfolgreich"
+      "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+      "reconfigure_successful": "Die Konfiguration wurde aktualisiert",
+      "wrong_device": "Diese URL gehört zu einem anderen OpenSprinkler-Controller"
     },
     "error": {
       "invalid_url": "URL ist ungültig (Beispiel: http://192.168.0.1)",
@@ -28,6 +30,19 @@
           "password": "Passwort"
         },
         "title": "Neues Passwort eingeben"
+      },
+      "reconfigure": {
+        "data": {
+          "url": "URL",
+          "verify_ssl": "SSL-Zertifikat prüfen (sicherer wenn aktiviert)"
+        },
+        "title": "OpenSprinkler-URL ändern"
+      },
+      "reconfigure_mac": {
+        "data": {
+          "mac": "MAC Addresse"
+        },
+        "title": "MAC-Adresse bestätigen"
       }
     }
   },

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -35,9 +35,10 @@
       "reconfigure": {
         "data": {
           "url": "URL",
-          "verify_ssl": "Verify SSL Certificate (Safer when checked)"
+          "verify_ssl": "Verify SSL certificate"
         },
-        "title": "Change the OpenSprinkler controller URL"
+        "description": "Enter the new controller URL. The stored password is used to connect.",
+        "title": "Reconfigure OpenSprinkler"
       },
       "reconfigure_mac": {
         "data": {

--- a/custom_components/opensprinkler/translations/en.json
+++ b/custom_components/opensprinkler/translations/en.json
@@ -3,7 +3,9 @@
   "config": {
     "abort": {
       "already_configured": "Device is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
+      "wrong_device": "This URL belongs to a different OpenSprinkler controller"
     },
     "error": {
       "invalid_url": "URL is malformed (example: http://192.168.0.1)",
@@ -29,6 +31,19 @@
           "password": "Password"
         },
         "title": "Enter new password"
+      },
+      "reconfigure": {
+        "data": {
+          "url": "URL",
+          "verify_ssl": "Verify SSL Certificate (Safer when checked)"
+        },
+        "title": "Change the OpenSprinkler controller URL"
+      },
+      "reconfigure_mac": {
+        "data": {
+          "mac": "MAC Address"
+        },
+        "title": "Confirm the OpenSprinkler MAC address"
       }
     }
   },

--- a/custom_components/opensprinkler/translations/pt.json
+++ b/custom_components/opensprinkler/translations/pt.json
@@ -35,9 +35,10 @@
       "reconfigure": {
         "data": {
           "url": "URL",
-          "verify_ssl": "Verificar Certificado SSL (Mais seguro quando marcado)"
+          "verify_ssl": "Verificar certificado SSL"
         },
-        "title": "Alterar o URL do controlador OpenSprinkler"
+        "description": "Introduza o novo URL do controlador. A palavra-passe guardada é usada para ligar.",
+        "title": "Reconfigurar o OpenSprinkler"
       },
       "reconfigure_mac": {
         "data": {

--- a/custom_components/opensprinkler/translations/pt.json
+++ b/custom_components/opensprinkler/translations/pt.json
@@ -3,7 +3,9 @@
   "config": {
     "abort": {
       "already_configured": "O dispositivo já está configurado",
-      "reauth_successful": "A re-autenticação foi bem-sucedida"
+      "reauth_successful": "A re-autenticação foi bem-sucedida",
+      "reconfigure_successful": "A reconfiguração foi bem-sucedida",
+      "wrong_device": "Este URL pertence a um controlador OpenSprinkler diferente"
     },
     "error": {
       "invalid_url": "O URL é inválido (exemplo: http://192.168.0.1)",
@@ -29,6 +31,19 @@
           "password": "Palavra-passe"
         },
         "title": "Introduza a nova palavra-passe"
+      },
+      "reconfigure": {
+        "data": {
+          "url": "URL",
+          "verify_ssl": "Verificar Certificado SSL (Mais seguro quando marcado)"
+        },
+        "title": "Alterar o URL do controlador OpenSprinkler"
+      },
+      "reconfigure_mac": {
+        "data": {
+          "mac": "Endereço MAC"
+        },
+        "title": "Confirmar o endereço MAC do OpenSprinkler"
       }
     }
   },

--- a/custom_components/opensprinkler/translations/sk.json
+++ b/custom_components/opensprinkler/translations/sk.json
@@ -35,9 +35,10 @@
       "reconfigure": {
         "data": {
           "url": "URL",
-          "verify_ssl": "Overiť SSL certifikát (Bezpečnejšie keď je skontrolované)"
+          "verify_ssl": "Overiť SSL certifikát"
         },
-        "title": "Zmeniť URL adresu ovládača OpenSprinkler"
+        "description": "Zadajte novú URL adresu ovládača. Na pripojenie sa použije uložené heslo.",
+        "title": "Prekonfigurovať OpenSprinkler"
       },
       "reconfigure_mac": {
         "data": {

--- a/custom_components/opensprinkler/translations/sk.json
+++ b/custom_components/opensprinkler/translations/sk.json
@@ -3,7 +3,9 @@
   "config": {
     "abort": {
       "already_configured": "Zariadenie je už nakonfigurované",
-      "reauth_successful": "Opätovné overenie bolo úspešné"
+      "reauth_successful": "Opätovné overenie bolo úspešné",
+      "reconfigure_successful": "Rekonfigurácia bola úspešná",
+      "wrong_device": "Táto adresa URL patrí inému ovládaču OpenSprinkler"
     },
     "error": {
       "invalid_url": "Adresa URL má nesprávny tvar (príklad: http://192.168.0.1)",
@@ -29,6 +31,19 @@
           "password": "Heslo"
         },
         "title": "Zadajte nové heslo"
+      },
+      "reconfigure": {
+        "data": {
+          "url": "URL",
+          "verify_ssl": "Overiť SSL certifikát (Bezpečnejšie keď je skontrolované)"
+        },
+        "title": "Zmeniť URL adresu ovládača OpenSprinkler"
+      },
+      "reconfigure_mac": {
+        "data": {
+          "mac": "MAC adresa"
+        },
+        "title": "Potvrdiť MAC adresu OpenSprinkler"
       }
     }
   },

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "OpenSprinkler integration for Home Assistant",
-  "homeassistant": "2024.2.0",
+  "homeassistant": "2024.11.0",
   "render_readme": true
 }

--- a/requirements-test-ha-2024.11.txt
+++ b/requirements-test-ha-2024.11.txt
@@ -1,0 +1,5 @@
+homeassistant==2024.11.0
+pytest-homeassistant-custom-component==0.13.181
+pyopensprinkler==0.7.20
+# HA 2024.11.0 imports fail with josepy 2.x (ComparableX509 was removed)
+josepy==1.14.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,21 +6,16 @@ from pathlib import Path
 
 import pytest
 
-_REPO_ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "custom_components"))
+# Add custom_components to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "custom_components"))
 
 if importlib.util.find_spec("pytest_homeassistant_custom_component"):
     pytest_plugins = ["pytest_homeassistant_custom_component"]
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _allow_pycares_shutdown_thread():
-    """Start pycares' daemon before HA teardown snapshots threads.
-
-    Closing an aiohttp session can create Thread(_run_safe_shutdown_loop).
-    If that happens mid-test, pytest-homeassistant treats it as a leak.
-    """
+def allow_pycares_thread():
+    """Avoid HA teardown failing on pycares' shutdown thread."""
     try:
         import pycares
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,30 @@
 """Pytest configuration for hass-opensprinkler tests."""
 
+import importlib.util
 import sys
 from pathlib import Path
 
-# Add custom_components to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "custom_components"))
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "custom_components"))
+
+if importlib.util.find_spec("pytest_homeassistant_custom_component"):
+    pytest_plugins = ["pytest_homeassistant_custom_component"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _allow_pycares_shutdown_thread():
+    """Start pycares' daemon before HA teardown snapshots threads.
+
+    Closing an aiohttp session can create Thread(_run_safe_shutdown_loop).
+    If that happens mid-test, pytest-homeassistant treats it as a leak.
+    """
+    try:
+        import pycares
+
+        pycares._shutdown_manager.start()
+    except Exception:
+        pass
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,4 +22,3 @@ def allow_pycares_thread():
         pycares._shutdown_manager.start()
     except Exception:
         pass
-    yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -19,8 +19,6 @@ from pyopensprinkler import OpenSprinklerAuthError, OpenSprinklerConnectionError
 
 pytest.importorskip("pytest_homeassistant_custom_component")
 
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 OLD_URL = "http://192.168.1.10"
 NEW_URL = "http://192.168.1.50"
 PASSWORD = "secret"
@@ -57,6 +55,8 @@ def mock_setup_entry():
 
 
 def mock_entry(hass):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=UNIQUE_ID,
@@ -207,7 +207,9 @@ async def test_reconfigure_wrong_device(hass, enable_custom_integrations):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_reconfigure_without_api_mac_asks_for_mac(hass, enable_custom_integrations):
+async def test_reconfigure_without_api_mac_asks_for_mac(
+    hass, enable_custom_integrations
+):
     """Firmware with no API MAC asks for the MAC on a second step."""
     entry = mock_entry(hass)
     controller = MockController(mac=None)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,302 @@
+"""Tests for the OpenSprinkler reconfigure config flow."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp.client_exceptions import InvalidURL
+from homeassistant.config_entries import SOURCE_RECONFIGURE
+from homeassistant.const import (
+    CONF_MAC,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.util import slugify
+from pyopensprinkler import OpenSprinklerAuthError, OpenSprinklerConnectionError
+
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+from custom_components.opensprinkler.const import DOMAIN  # noqa: E402
+
+OLD_URL = "http://192.168.1.10"
+NEW_URL = "http://192.168.1.50"
+PASSWORD = "secret"
+MAC = "AA:BB:CC:DD:EE:FF"
+UNIQUE_ID = slugify(MAC)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def add_custom_component_path():
+    """Make HA discover this repo's custom component."""
+    import custom_components
+
+    custom_path = str(Path(__file__).resolve().parents[1] / "custom_components")
+    if custom_path not in list(custom_components.__path__):
+        custom_components.__path__.insert(0, custom_path)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_setup_entry(add_custom_component_path):
+    """Keep setup/unload mocked for the whole module so hass teardown stays clean."""
+    import custom_components.opensprinkler as ospi
+
+    with (
+        patch.object(ospi, "async_setup_entry", AsyncMock(return_value=True)),
+        patch.object(ospi, "async_unload_entry", AsyncMock(return_value=True)),
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_reload",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.opensprinkler.config_flow.async_get_clientsession",
+            return_value=MagicMock(),
+        ),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def enable_custom_integrations_fixture(enable_custom_integrations):
+    """Rescan custom integrations after the path is registered."""
+    yield
+
+
+def _mock_controller(mac=MAC):
+    controller = MagicMock()
+    controller.mac_address = mac
+    controller.refresh = AsyncMock()
+    return controller
+
+
+def _mock_entry(hass) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=UNIQUE_ID,
+        title="OpenSprinkler",
+        data={
+            CONF_URL: OLD_URL,
+            CONF_PASSWORD: PASSWORD,
+            CONF_NAME: "OpenSprinkler",
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def _start_reconfigure(hass, entry):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+
+
+async def test_reconfigure_form_shows_current_url(hass, mock_setup_entry):
+    """The first reconfigure form is URL + Verify SSL, prefilled."""
+    entry = _mock_entry(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert CONF_URL in result["data_schema"].schema
+    assert CONF_VERIFY_SSL in result["data_schema"].schema
+    assert CONF_PASSWORD not in result["data_schema"].schema
+    assert CONF_MAC not in result["data_schema"].schema
+
+
+async def test_reconfigure_updates_existing_entry(hass, mock_setup_entry):
+    """A matching controller updates the same entry in place."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller()
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ) as mock_api:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: False},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.data[CONF_URL] == NEW_URL
+    assert entry.data[CONF_VERIFY_SSL] is False
+    assert entry.data[CONF_PASSWORD] == PASSWORD
+    assert entry.unique_id == UNIQUE_ID
+    mock_api.assert_called_once()
+    assert mock_api.call_args.args[0] == NEW_URL
+    assert mock_api.call_args.args[1] == PASSWORD
+
+
+async def test_reconfigure_cannot_connect(hass, mock_setup_entry):
+    """Connection failures stay on the first form and do not update the entry."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller()
+    controller.refresh.side_effect = OpenSprinklerConnectionError
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: True},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"]["base"] == "cannot_connect"
+    assert entry.data[CONF_URL] == OLD_URL
+
+
+async def test_reconfigure_invalid_auth(hass, mock_setup_entry):
+    """Auth failures stay on the first form and do not update the entry."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller()
+    controller.refresh.side_effect = OpenSprinklerAuthError
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: True},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == "invalid_auth"
+    assert entry.data[CONF_URL] == OLD_URL
+
+
+async def test_reconfigure_invalid_url(hass, mock_setup_entry):
+    """Malformed URLs stay on the first form."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller()
+    controller.refresh.side_effect = InvalidURL("not-a-url")
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: "not-a-url", CONF_VERIFY_SSL: True},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == "invalid_url"
+    assert entry.data[CONF_URL] == OLD_URL
+
+
+async def test_reconfigure_wrong_device(hass, mock_setup_entry):
+    """A different controller MAC is rejected and the entry is unchanged."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller(mac="11:22:33:44:55:66")
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: True},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert entry.data[CONF_URL] == OLD_URL
+    assert entry.unique_id == UNIQUE_ID
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_reconfigure_without_api_mac_asks_for_mac(hass, mock_setup_entry):
+    """Legacy firmware with no API MAC goes to the second step."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller(mac=None)
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: True},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_mac"
+    assert CONF_MAC in result["data_schema"].schema
+    assert entry.data[CONF_URL] == OLD_URL
+
+
+async def test_reconfigure_mac_matching_updates_entry(hass, mock_setup_entry):
+    """A matching manual MAC finishes reconfigure on the same entry."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller(mac=None)
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: False},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MAC: MAC},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.data[CONF_URL] == NEW_URL
+    assert entry.data[CONF_VERIFY_SSL] is False
+    assert entry.data[CONF_PASSWORD] == PASSWORD
+    assert entry.unique_id == UNIQUE_ID
+
+
+async def test_reconfigure_mac_mismatch_aborts(hass, mock_setup_entry):
+    """A different manual MAC is rejected and the entry is unchanged."""
+    entry = _mock_entry(hass)
+    controller = _mock_controller(mac=None)
+
+    result = await _start_reconfigure(hass, entry)
+    with patch(
+        "custom_components.opensprinkler.config_flow.OpenSprinkler",
+        return_value=controller,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: NEW_URL, CONF_VERIFY_SSL: True},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MAC: "11:22:33:44:55:66"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert entry.data[CONF_URL] == OLD_URL
+    assert entry.unique_id == UNIQUE_ID
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,5 @@
-"""Tests for the OpenSprinkler reconfigure config flow."""
+"""Tests for config flow reconfiguration."""
 
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,15 +14,12 @@ from homeassistant.const import (
 )
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.util import slugify
+from opensprinkler.const import DOMAIN
 from pyopensprinkler import OpenSprinklerAuthError, OpenSprinklerConnectionError
 
 pytest.importorskip("pytest_homeassistant_custom_component")
 
-from pytest_homeassistant_custom_component.common import (  # noqa: E402
-    MockConfigEntry,
-)
-
-from custom_components.opensprinkler.const import DOMAIN  # noqa: E402
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 OLD_URL = "http://192.168.1.10"
 NEW_URL = "http://192.168.1.50"
@@ -32,19 +28,17 @@ MAC = "AA:BB:CC:DD:EE:FF"
 UNIQUE_ID = slugify(MAC)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def add_custom_component_path():
-    """Make HA discover this repo's custom component."""
-    import custom_components
+class MockController:
+    """Mock OpenSprinkler controller."""
 
-    custom_path = str(Path(__file__).resolve().parents[1] / "custom_components")
-    if custom_path not in list(custom_components.__path__):
-        custom_components.__path__.insert(0, custom_path)
+    def __init__(self, mac=MAC):
+        self.mac_address = mac
+        self.refresh = AsyncMock()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_setup_entry(add_custom_component_path):
-    """Keep setup/unload mocked for the whole module so hass teardown stays clean."""
+def mock_setup_entry():
+    """Skip a full integration setup during reconfigure."""
     import custom_components.opensprinkler as ospi
 
     with (
@@ -62,20 +56,7 @@ def mock_setup_entry(add_custom_component_path):
         yield
 
 
-@pytest.fixture(autouse=True)
-def enable_custom_integrations_fixture(enable_custom_integrations):
-    """Rescan custom integrations after the path is registered."""
-    yield
-
-
-def _mock_controller(mac=MAC):
-    controller = MagicMock()
-    controller.mac_address = mac
-    controller.refresh = AsyncMock()
-    return controller
-
-
-def _mock_entry(hass) -> MockConfigEntry:
+def mock_entry(hass):
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=UNIQUE_ID,
@@ -91,18 +72,18 @@ def _mock_entry(hass) -> MockConfigEntry:
     return entry
 
 
-async def _start_reconfigure(hass, entry):
+async def start_reconfigure(hass, entry):
     return await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
     )
 
 
-async def test_reconfigure_form_shows_current_url(hass, mock_setup_entry):
-    """The first reconfigure form is URL + Verify SSL, prefilled."""
-    entry = _mock_entry(hass)
+async def test_reconfigure_form_shows_current_url(hass, enable_custom_integrations):
+    """The first form is URL and verify SSL, without password or MAC."""
+    entry = mock_entry(hass)
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
@@ -112,12 +93,12 @@ async def test_reconfigure_form_shows_current_url(hass, mock_setup_entry):
     assert CONF_MAC not in result["data_schema"].schema
 
 
-async def test_reconfigure_updates_existing_entry(hass, mock_setup_entry):
-    """A matching controller updates the same entry in place."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller()
+async def test_reconfigure_updates_existing_entry(hass, enable_custom_integrations):
+    """A matching controller updates the existing entry."""
+    entry = mock_entry(hass)
+    controller = MockController()
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -140,13 +121,13 @@ async def test_reconfigure_updates_existing_entry(hass, mock_setup_entry):
     assert mock_api.call_args.args[1] == PASSWORD
 
 
-async def test_reconfigure_cannot_connect(hass, mock_setup_entry):
-    """Connection failures stay on the first form and do not update the entry."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller()
+async def test_reconfigure_cannot_connect(hass, enable_custom_integrations):
+    """A connection error stays on the form and does not update the entry."""
+    entry = mock_entry(hass)
+    controller = MockController()
     controller.refresh.side_effect = OpenSprinklerConnectionError
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -162,13 +143,13 @@ async def test_reconfigure_cannot_connect(hass, mock_setup_entry):
     assert entry.data[CONF_URL] == OLD_URL
 
 
-async def test_reconfigure_invalid_auth(hass, mock_setup_entry):
-    """Auth failures stay on the first form and do not update the entry."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller()
+async def test_reconfigure_invalid_auth(hass, enable_custom_integrations):
+    """An auth error stays on the form and does not update the entry."""
+    entry = mock_entry(hass)
+    controller = MockController()
     controller.refresh.side_effect = OpenSprinklerAuthError
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -183,13 +164,13 @@ async def test_reconfigure_invalid_auth(hass, mock_setup_entry):
     assert entry.data[CONF_URL] == OLD_URL
 
 
-async def test_reconfigure_invalid_url(hass, mock_setup_entry):
-    """Malformed URLs stay on the first form."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller()
+async def test_reconfigure_invalid_url(hass, enable_custom_integrations):
+    """A malformed URL stays on the form."""
+    entry = mock_entry(hass)
+    controller = MockController()
     controller.refresh.side_effect = InvalidURL("not-a-url")
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -204,12 +185,12 @@ async def test_reconfigure_invalid_url(hass, mock_setup_entry):
     assert entry.data[CONF_URL] == OLD_URL
 
 
-async def test_reconfigure_wrong_device(hass, mock_setup_entry):
+async def test_reconfigure_wrong_device(hass, enable_custom_integrations):
     """A different controller MAC is rejected and the entry is unchanged."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller(mac="11:22:33:44:55:66")
+    entry = mock_entry(hass)
+    controller = MockController(mac="11:22:33:44:55:66")
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -226,12 +207,12 @@ async def test_reconfigure_wrong_device(hass, mock_setup_entry):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_reconfigure_without_api_mac_asks_for_mac(hass, mock_setup_entry):
-    """Legacy firmware with no API MAC goes to the second step."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller(mac=None)
+async def test_reconfigure_without_api_mac_asks_for_mac(hass, enable_custom_integrations):
+    """Firmware with no API MAC asks for the MAC on a second step."""
+    entry = mock_entry(hass)
+    controller = MockController(mac=None)
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -247,12 +228,12 @@ async def test_reconfigure_without_api_mac_asks_for_mac(hass, mock_setup_entry):
     assert entry.data[CONF_URL] == OLD_URL
 
 
-async def test_reconfigure_mac_matching_updates_entry(hass, mock_setup_entry):
-    """A matching manual MAC finishes reconfigure on the same entry."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller(mac=None)
+async def test_reconfigure_mac_matching_updates_entry(hass, enable_custom_integrations):
+    """A matching manual MAC updates the existing entry."""
+    entry = mock_entry(hass)
+    controller = MockController(mac=None)
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,
@@ -276,12 +257,12 @@ async def test_reconfigure_mac_matching_updates_entry(hass, mock_setup_entry):
     assert entry.unique_id == UNIQUE_ID
 
 
-async def test_reconfigure_mac_mismatch_aborts(hass, mock_setup_entry):
+async def test_reconfigure_mac_mismatch_aborts(hass, enable_custom_integrations):
     """A different manual MAC is rejected and the entry is unchanged."""
-    entry = _mock_entry(hass)
-    controller = _mock_controller(mac=None)
+    entry = mock_entry(hass)
+    controller = MockController(mac=None)
 
-    result = await _start_reconfigure(hass, entry)
+    result = await start_reconfigure(hass, entry)
     with patch(
         "custom_components.opensprinkler.config_flow.OpenSprinkler",
         return_value=controller,


### PR DESCRIPTION
## Summary
- Adds a Home Assistant **Reconfigure** flow so the OpenSprinkler controller URL (IP or hostname) and Verify SSL setting can be changed on the existing config entry. Device IDs, entity IDs, and automations stay the same.
- First form is URL + Verify SSL only. The stored password is reused. If the API returns a MAC, it must match the existing unique ID (`wrong_device` otherwise). If the API has no MAC (legacy firmware), a second `reconfigure_mac` step asks for the MAC and requires the same match.
- Raises the HACS minimum to Home Assistant **2024.11.0** and adds a pinned CI job for that version, because the flow uses the 2024.11 reconfigure helpers.
- Closes #385. This is the current-HA way to do what #163 asked for in 2022.

**Out of scope:** duplicate-add / DHCP auto-update, a password field on Reconfigure, Options flow, and Reauth modernization.

**Known limitation:** Simultaneous controller URL + password changes are unsupported in this PR; see Known Limitations.

## Test plan
- [x] Local: `homeassistant==2024.11.0` + `pytest-homeassistant-custom-component==0.13.181` on Python 3.12 — 48 tests passed (9 new config-flow cases + existing suite)
- [ ] CI: existing unpinned Tests job still green
- [ ] CI: new `Home Assistant 2024.11 compatibility` job green
- [ ] Live (later, with the reporter; do **not** uninstall the integration): copy `custom_components/opensprinkler` over the installed integration, then Reconfigure when the old URL is already dead, and confirm device/entity IDs are unchanged
- [ ] Confirm pointing Reconfigure at a *different* controller is rejected
- [ ] Confirm a URL change with a *new* password is not claimed to work in this PR

Made with [Cursor](https://cursor.com)