### PR TITLE
Feature: additional calendar logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,10 +302,19 @@ The Calendar entity currently considers the following OpenSprinkler settings:
 - Additional Start Times, Repeating and Fixed
 - Date Range
 - Rain Delay
+- Weather Restrictions
 - Station Groups
 - Station Delay
 - Station Ignore Rain Delay
 - Weather Adjustment, current day only, using multi-day averages if selected
+
+The following settings/features are not supported at this time:
+
+- Paused or Stopped runs
+- Master Stations
+- Sensor Adjustment
+- Manual and Run-once programs
+- Program Name Annotations
 
 An alternate view of the data similar to OpenSprinkler's Program Preview is available via the
 [OpenSprinkler Preview Card](https://github.com/EdLeckert/opensprinkler-preview-card). It shows

--- a/custom_components/opensprinkler/calendar.py
+++ b/custom_components/opensprinkler/calendar.py
@@ -384,7 +384,10 @@ class OpenSprinklerCalendar(CalendarEntity):
 
             program_qualifies, restrict_to_ignored = (
                 self._get_program_final_run_decision(
-                    today, calendar_day, original_program_start_time, has_rain_delay_ignored_stations
+                    today,
+                    calendar_day,
+                    original_program_start_time,
+                    has_rain_delay_ignored_stations,
                 )
             )
 
@@ -411,7 +414,11 @@ class OpenSprinklerCalendar(CalendarEntity):
         return runs
 
     def _get_program_final_run_decision(
-        self, today, calendar_day, original_program_start_time, has_rain_delay_ignored_stations
+        self,
+        today,
+        calendar_day,
+        original_program_start_time,
+        has_rain_delay_ignored_stations,
     ):
         """Check for Weather Restriction, Rain Delay."""
         # Rain delay program selection:

--- a/custom_components/opensprinkler/calendar.py
+++ b/custom_components/opensprinkler/calendar.py
@@ -1,3 +1,4 @@
+import calendar
 import logging
 from datetime import date, datetime, time, timedelta
 from math import trunc
@@ -51,7 +52,7 @@ class OpenSprinklerCalendar(CalendarEntity):
         """Initialize the calendar."""
         self._controller = controller
         self.coordinator = coordinator
-        self._attr_name = "Opensprinkler Schedule"
+        self._attr_name = f"{name} Schedule"
         self._attr_unique_id = f"{entry.unique_id}_calendar"
         self._event = None
 
@@ -240,7 +241,12 @@ class OpenSprinklerCalendar(CalendarEntity):
 
     def _can_monthly_run_on_day(self, program: dict, check_date: datetime) -> bool:
         """Determine if a monthly program can run on a given date."""
-        return program.monthly_day == check_date.day
+        run_day = program.monthly_day
+        if run_day == 0:  # Last day of month
+            year = check_date.year
+            month = check_date.month
+            _, run_day = calendar.monthrange(year, month)
+        return run_day == check_date.day
 
     def _can_interval_run_on_day(self, program: dict, check_date: datetime) -> bool:
         """Determine if an interval program can run on a given date."""
@@ -256,6 +262,8 @@ class OpenSprinklerCalendar(CalendarEntity):
             program.odd_even_restriction_name is None
             or program.odd_even_restriction_name == "odd_days"  # odd days only
             and check_date.day % 2 == 1
+            and check_date.day != 31
+            and not (check_date.month == 2 and check_date.day == 29)
             or program.odd_even_restriction_name == "even_days"  # even days only
             and check_date.day % 2 == 0
         ):
@@ -376,7 +384,7 @@ class OpenSprinklerCalendar(CalendarEntity):
 
             program_qualifies, restrict_to_ignored = (
                 self._get_program_final_run_decision(
-                    today, original_program_start_time, has_rain_delay_ignored_stations
+                    today, calendar_day, original_program_start_time, has_rain_delay_ignored_stations
                 )
             )
 
@@ -402,10 +410,8 @@ class OpenSprinklerCalendar(CalendarEntity):
 
         return runs
 
-    # def _get_program_final_run_decision(
-    # self, today, calendar_day, original_program_start_time, has_rain_delay_ignored_stations):
     def _get_program_final_run_decision(
-        self, today, original_program_start_time, has_rain_delay_ignored_stations
+        self, today, calendar_day, original_program_start_time, has_rain_delay_ignored_stations
     ):
         """Check for Weather Restriction, Rain Delay."""
         # Rain delay program selection:
@@ -419,15 +425,13 @@ class OpenSprinklerCalendar(CalendarEntity):
         # If there is no rain delay, or if there is a rain delay but the program has stations
         # that ignore it, program qualifies.
 
-        # A Weather Restriction blocks all programs for the current day only. (*** Included in future PR ***)
+        # A Weather Restriction blocks all programs for the current day only.
 
         restrict_to_ignored = False
 
-        # Next lines reserved for future PR
-        # if today == calendar_day and self._controller.weather_restriction_active:
-        #     program_qualifies = False
-        # elif self._controller.rain_delay_active:
-        if self._controller.rain_delay_active:
+        if today == calendar_day and self._controller.weather_restriction_active:
+            program_qualifies = False
+        elif self._controller.rain_delay_active:
             rain_delay_end_time = self._epoch_to_local(
                 self._controller.rain_delay_stop_time
             )

--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
   "requirements": ["pyopensprinkler==0.7.22", "suntime==1.3.2"],
-  "version": "2.1.1"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
This PR provides additional logic to better mimic the controller's logic. It adds or fixes:

- Weather Restriction support
- Improves Odd Day Restriction to skip the 31st and Feb 29th
- Improves Monthly Scheduling to support last day of month runs
- Also uses controller name for Calendar entity, rather than hardcoded "OpenSprinkler"
