### PR TITLE
Relax suntime dependency

### DIFF
--- a/custom_components/opensprinkler/manifest.json
+++ b/custom_components/opensprinkler/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/vinteo/hass-opensprinkler",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vinteo/hass-opensprinkler/issues",
-  "requirements": ["pyopensprinkler==0.7.22", "suntime==1.3.2"],
+  "requirements": ["pyopensprinkler==0.7.22", "suntime>=1.3.2"],
   "version": "2.2.0"
 }


### PR DESCRIPTION
There are no known issues with newer versions of suntime, and it's generally frowned upon to be pessimistic about your dependencies in the Python ecosystem.

This fixes https://github.com/vinteo/hass-opensprinkler/issues/393